### PR TITLE
chore: sync website package-lock.json and fix playwright config

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2770,7 +2770,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -8936,6 +8935,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testMatch: '**/*.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
Updates `website/package-lock.json` to match `package.json` dependencies (likely desynchronized during a previous merge).
Also updates `website/playwright.config.ts` to exclusively match `**/*.spec.ts` files, preventing Playwright from attempting to execute Vitest tests (`**/*.test.ts`) which causes failures.

Resolves #89.

---
*PR created automatically by Jules for task [14129333018026811016](https://jules.google.com/task/14129333018026811016) started by @jjgroenendijk*