### PR TITLE
docs: add resolution note for PR #88 merge conflict

### DIFF
--- a/docs/troubleshooting/closed/2026-02-03_pr-88-merge-conflict.md
+++ b/docs/troubleshooting/closed/2026-02-03_pr-88-merge-conflict.md
@@ -1,0 +1,16 @@
+# Merge Conflict Resolution for PR #88
+
+**Date:** 2026-02-03
+**Issue:** #89
+**PR:** #88
+
+## Issue Description
+A merge conflict was detected for PR #88 ("build(deps): bump react-dom from 19.2.3 to 19.2.4 in /website"). The automated system created Issue #89 to request resolution.
+
+## Investigation
+Upon investigation, it was found that PR #88 was already in `MERGED` state. The branch `dependabot/npm_and_yarn/website/react-dom-19.2.4` had been deleted.
+The changes from the PR (updating `react-dom` version) were verified to be present in `website/package.json` and `website/package-lock.json` in the `main` branch.
+
+## Resolution
+The conflict was likely resolved externally (e.g., by Dependabot rebasing and merging, or a user manual merge) before the agent session began or concurrently.
+Issue #89 was closed as the underlying PR is successfully merged.


### PR DESCRIPTION
This PR adds a documentation file in `docs/troubleshooting/closed/` detailing the investigation and resolution of the merge conflict reported for PR #88.
The investigation found that PR #88 was already merged and the conflict was resolved externally. Issue #89 was closed accordingly.

---
*PR created automatically by Jules for task [5476928986751158130](https://jules.google.com/task/5476928986751158130) started by @jjgroenendijk*