### PR TITLE
docs: resolve stale merge conflict report for PR #82

### DIFF
--- a/docs/troubleshooting/closed/2026-02-03_pr_82_conflict.md
+++ b/docs/troubleshooting/closed/2026-02-03_pr_82_conflict.md
@@ -1,0 +1,19 @@
+# PR #82 Merge Conflict Resolution
+
+**Date**: 2026-02-03
+**Status**: Closed
+**PR**: #82
+
+## Issue
+A merge conflict was reported for PR #82 "build(deps): bump next from 16.1.4 to 16.1.6 in /website".
+
+## Investigation
+- Checked the files in `main` branch (`website/package.json` and `website/package-lock.json`).
+- Confirmed that `next` is already at version `16.1.6`.
+- Checked the status of PR #82 using `gh pr view 82`.
+- Found that PR #82 was already merged on 2026-01-29 by `app/github-actions`.
+
+## Resolution
+- Validated that the changes are present in the codebase.
+- No further action is required as the PR is already merged and the dependency is updated.
+- The reported merge conflict was likely a stale status or misunderstanding of the PR state.


### PR DESCRIPTION
Investigated the reported merge conflict for PR #82. Found that the PR was already merged on 2026-01-29 and the dependency update (next 16.1.6) was already present in the `main` branch. Created a troubleshooting report `docs/troubleshooting/closed/2026-02-03_pr_82_conflict.md` to document the findings and resolution. No code changes were necessary.

---
*PR created automatically by Jules for task [13126425345155321422](https://jules.google.com/task/13126425345155321422) started by @jjgroenendijk*