### PR TITLE
docs: update requirements and readme with deployment info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,14 @@
     - All new features must include unit tests and Playwright tests (if applicable).
     - Ensure everything can be tested by AI systems.
 
-6.  **Documentation**:
+6.  **Deployment & CI**:
+    - The game must work as a static website hosted on GitHub Pages.
+    - CI must be set up to automatically test and publish the game using GitHub Pages.
+
+7.  **Documentation**:
     - Keep README.md updated, including screenshots for visual features.
 
-7.  **Issue Encountered**:
+8.  **Issue Encountered**:
     - If an issue is encountered, you **MUST STOP ALL WORK**.
     - Do some quick research about the issue.
     - Create a GitHub issue for it.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This repository includes a 3D Minecraft-like exploration game to demonstrate web
 
 ![Minecraft Explorer Game](docs/screenshots/gameplay.png)
 
+**Play the game online at: [jjgroenendijk.nl/test-repo](https://jjgroenendijk.nl/test-repo)**
+
 ### Features
 - **Voxel World:** Add and remove blocks (Dirt, Grass, Glass, Wood, Log).
 - **Physics:** Jumping and collision detection.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -38,3 +38,8 @@ This repository integrates **Google Jules** via its REST API. The goal is to all
 ## Future Scope
 *   Two-way sync: Forwarding comments from GitHub to the Jules Session.
 *   Polling: Automatically updating the GitHub issue when Jules completes the task or opens a PR.
+
+## Game Requirements
+*   **Static Website:** The game must be designed to work as a static website.
+*   **Deployment:** Must be hosted on GitHub Pages.
+*   **CI/CD:** Automated testing and publishing to GitHub Pages via GitHub Actions is required.


### PR DESCRIPTION
Updated AGENTS.md, docs/requirements.md, and README.md to specify that the game must be a static website hosted on GitHub Pages with CI/CD, and added the public demo URL.

---
*PR created automatically by Jules for task [2585491809137349912](https://jules.google.com/task/2585491809137349912) started by @jjgroenendijk*