### PR TITLE
Fix lint errors in Minecraft game components and mark backlog item as complete

### DIFF
--- a/docs/backlog/closed/002_minecraft_exploration.md
+++ b/docs/backlog/closed/002_minecraft_exploration.md
@@ -1,13 +1,14 @@
 # Minecraft-like 3D World Exploration
 
 **Value**: High (Demonstrates 3D capabilities and interactive gameplay)
+**Status**: Done
 
 ## What
 A browser-based 3D exploration game hosted on GitHub Pages.
-- Voxel-based world (cubes).
-- First-person movement (WASD + Jump).
-- Ability to add/remove blocks.
-- Physics interactions.
+- [x] Voxel-based world (cubes).
+- [x] First-person movement (WASD + Jump).
+- [x] Ability to add/remove blocks.
+- [x] Physics interactions.
 
 ## Why
 To create an engaging demo for the repository and showcase Next.js + Three.js capabilities.

--- a/website/components/game/Cube.tsx
+++ b/website/components/game/Cube.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useBox } from '@react-three/cannon';
+import { Mesh } from 'three';
 import { useStore, CubeType } from '../../lib/store';
 import { useState } from 'react';
 
@@ -13,14 +14,14 @@ const colors: Record<CubeType, string> = {
 };
 
 export const Cube = ({ position, texture }: { position: [number, number, number]; texture: CubeType }) => {
-  const [ref] = useBox(() => ({ type: 'Static', position }));
+  const [ref] = useBox<Mesh>(() => ({ type: 'Static', position }));
   const addCube = useStore((state) => state.addCube);
   const removeCube = useStore((state) => state.removeCube);
   const [hover, setHover] = useState(false);
 
   return (
     <mesh
-      ref={ref as any}
+      ref={ref}
       onPointerMove={(e) => {
         e.stopPropagation();
         setHover(true);

--- a/website/components/game/Ground.tsx
+++ b/website/components/game/Ground.tsx
@@ -1,20 +1,22 @@
 'use client';
 
 import { usePlane } from '@react-three/cannon';
+import { Mesh } from 'three';
 import { useStore } from '../../lib/store';
 
 export const Ground = () => {
-  const [ref] = usePlane(() => ({ rotation: [-Math.PI / 2, 0, 0], position: [0, -0.5, 0] }));
+  const [ref] = usePlane<Mesh>(() => ({ rotation: [-Math.PI / 2, 0, 0], position: [0, -0.5, 0] }));
   const addCube = useStore((state) => state.addCube);
 
   return (
     <mesh
-      ref={ref as any}
+      ref={ref}
       onClick={(e) => {
         e.stopPropagation();
         if (e.altKey) return;
 
-        const [x, y, z] = Object.values(e.point).map(val => Math.round(val));
+        const x = Math.round(e.point.x);
+        const z = Math.round(e.point.z);
         addCube(x, 0, z);
       }}
     >

--- a/website/components/game/Player.tsx
+++ b/website/components/game/Player.tsx
@@ -3,14 +3,14 @@
 import { useSphere } from '@react-three/cannon';
 import { useThree, useFrame } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
-import { Vector3 } from 'three';
+import { Vector3, Mesh } from 'three';
 import { PointerLockControls } from '@react-three/drei';
 
 const SPEED = 5;
 
 export const Player = () => {
   const { camera } = useThree();
-  const [ref, api] = useSphere(() => ({ mass: 1, type: 'Dynamic', position: [0, 5, 0] }));
+  const [ref, api] = useSphere<Mesh>(() => ({ mass: 1, type: 'Dynamic', position: [0, 5, 0] }));
 
   const movement = useRef({ forward: false, backward: false, left: false, right: false });
   const velocity = useRef([0, 0, 0]);
@@ -66,7 +66,7 @@ export const Player = () => {
 
   return (
     <>
-      <mesh ref={ref as any} />
+      <mesh ref={ref} />
       <PointerLockControls />
     </>
   );

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "@react-three/cannon": "^6.6.0",


### PR DESCRIPTION
- Fixed TypeScript `any` type usage in `Cube.tsx`, `Ground.tsx`, and `Player.tsx` by importing and using `Mesh` from `three` and proper generic types for cannon hooks.
- Added `test` script to `website/package.json`.
- Verified functionality with Vitest and Playwright tests.
- Moved `002_minecraft_exploration.md` to `docs/backlog/closed/` as the feature is fully implemented and verified.

---
*PR created automatically by Jules for task [9026509766578315845](https://jules.google.com/task/9026509766578315845) started by @jjgroenendijk*