### PR TITLE
Display Storage Usage in Downloader Dashboard

### DIFF
--- a/docs/backlog/closed/001_storage_usage.md
+++ b/docs/backlog/closed/001_storage_usage.md
@@ -1,0 +1,7 @@
+# Display Storage Usage in Dashboard
+
+## What
+Add a "Storage Usage" metric to the "Archive Snapshot" section of the Downloader Dashboard. This should display the total size of the `downloads` directory in a human-readable format (e.g., "1.2 GB").
+
+## Why
+Users need to know how much disk space their downloads are consuming to manage the storage volume effectively, especially since the application runs in a container with potentially limited persistent storage.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -7,6 +7,7 @@ import {
   appendHistory,
   clearHistory,
   ensureDataStorage,
+  getStorageUsage,
   readHistory,
   type DownloadRecord,
 } from "@/lib/archive-store";
@@ -61,8 +62,9 @@ export async function GET() {
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
   const records = await readHistory(paths);
+  const storageUsage = await getStorageUsage(paths.downloadsDir);
 
-  return NextResponse.json({ records });
+  return NextResponse.json({ records, storageUsage });
 }
 
 export async function POST(request: Request) {

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -20,6 +20,19 @@ interface ApiResponse {
   record?: DownloadRecord;
   records?: DownloadRecord[];
   error?: string;
+  storageUsage?: number;
+}
+
+function formatBytes(bytes: number, decimals = 2): string {
+  if (bytes === 0) return "0 B";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
 function formatTimestamp(value: string): string {
@@ -35,6 +48,7 @@ export function DownloaderDashboard() {
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
+  const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
   const [feedback, setFeedback] = useState<string>("Idle");
 
@@ -42,6 +56,9 @@ export function DownloaderDashboard() {
     const response = await fetch("/api/downloads", { method: "GET" });
     const payload = (await response.json()) as ApiResponse;
     setHistory(payload.records ?? []);
+    if (typeof payload.storageUsage === "number") {
+      setStorageUsage(payload.storageUsage);
+    }
   }
 
   useEffect(() => {
@@ -186,6 +203,10 @@ export function DownloaderDashboard() {
             <div>
               <span>Failed</span>
               <strong>{failedCount}</strong>
+            </div>
+            <div>
+              <span>Storage Usage</span>
+              <strong>{formatBytes(storageUsage)}</strong>
             </div>
           </div>
           <p>

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 
 import { type DataPaths } from "./ytdlp";
 
@@ -65,4 +66,26 @@ export async function appendHistory(
 
   const limited = history.slice(0, 200);
   await fs.writeFile(paths.historyFile, `${JSON.stringify(limited, null, 2)}\n`, "utf8");
+}
+
+export async function getStorageUsage(dirPath: string): Promise<number> {
+  let total = 0;
+
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        total += await getStorageUsage(fullPath);
+      } else if (entry.isFile()) {
+        const stats = await fs.stat(fullPath);
+        total += stats.size;
+      }
+    }
+  } catch {
+    return 0;
+  }
+
+  return total;
 }

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { getStorageUsage } from '../lib/archive-store';
+
+describe('getStorageUsage', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'archive-store-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns 0 for an empty directory', async () => {
+    const usage = await getStorageUsage(tempDir);
+    expect(usage).toBe(0);
+  });
+
+  it('calculates size of files in a directory', async () => {
+    const file1 = path.join(tempDir, 'file1.txt');
+    await fs.writeFile(file1, 'hello', 'utf8'); // 5 bytes
+    const usage = await getStorageUsage(tempDir);
+    expect(usage).toBe(5);
+  });
+
+  it('calculates size of files in nested directories', async () => {
+    const subDir = path.join(tempDir, 'subdir');
+    await fs.mkdir(subDir);
+    const file1 = path.join(tempDir, 'file1.txt');
+    const file2 = path.join(subDir, 'file2.txt');
+
+    await fs.writeFile(file1, 'hello', 'utf8'); // 5 bytes
+    await fs.writeFile(file2, 'world', 'utf8'); // 5 bytes
+
+    const usage = await getStorageUsage(tempDir);
+    expect(usage).toBe(10);
+  });
+
+  it('returns 0 if directory does not exist', async () => {
+    const nonExistent = path.join(tempDir, 'non-existent');
+    const usage = await getStorageUsage(nonExistent);
+    expect(usage).toBe(0);
+  });
+});


### PR DESCRIPTION
- Implemented `getStorageUsage` in `website/lib/archive-store.ts`.
- Updated `GET /api/downloads` to return `storageUsage`.
- Updated `DownloaderDashboard` to display storage usage in the "Archive Snapshot" section.
- Added unit tests in `website/tests/archive-store.test.ts`.
- Verified with Playwright.
- Closed backlog item `001_storage_usage.md`.

---
*PR created automatically by Jules for task [7639099890389432484](https://jules.google.com/task/7639099890389432484) started by @jjgroenendijk*