### PR TITLE
Fix CI failure by updating uv version to 0.9.7

### DIFF
--- a/.github/workflows/verify-codebase.yml
+++ b/.github/workflows/verify-codebase.yml
@@ -24,7 +24,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          version: "0.5.29"
+          version: "0.9.7"
 
       - name: Install dependencies
         run: uv sync --all-groups


### PR DESCRIPTION
Updated `uv` version in `.github/workflows/verify-codebase.yml` from `0.5.29` to `0.9.7` to fix CI failure due to download errors (503/500). Verified locally that tests pass with `uv 0.9.7`.

---
*PR created automatically by Jules for task [4647701576337648812](https://jules.google.com/task/4647701576337648812) started by @jjgroenendijk*