### PR TITLE
Display storage usage on downloader dashboard

### DIFF
--- a/docs/backlog/open/001_storage_usage.md
+++ b/docs/backlog/open/001_storage_usage.md
@@ -1,0 +1,7 @@
+# Storage Usage Display
+
+## What
+Display the total disk usage of the downloads directory on the main dashboard. This should be formatted in human-readable units (B, KB, MB, GB).
+
+## Why
+Users need to monitor the storage consumption of their archived videos to manage disk space effectively.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -7,6 +7,7 @@ import {
   appendHistory,
   clearHistory,
   ensureDataStorage,
+  getStorageUsage,
   readHistory,
   type DownloadRecord,
 } from "@/lib/archive-store";
@@ -61,8 +62,9 @@ export async function GET() {
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
   const records = await readHistory(paths);
+  const storageUsage = await getStorageUsage(paths);
 
-  return NextResponse.json({ records });
+  return NextResponse.json({ records, storageUsage });
 }
 
 export async function POST(request: Request) {

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -19,7 +19,16 @@ interface DownloadRecord {
 interface ApiResponse {
   record?: DownloadRecord;
   records?: DownloadRecord[];
+  storageUsage?: number;
   error?: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }
 
 function formatTimestamp(value: string): string {
@@ -35,6 +44,7 @@ export function DownloaderDashboard() {
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
+  const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
   const [feedback, setFeedback] = useState<string>("Idle");
 
@@ -42,6 +52,7 @@ export function DownloaderDashboard() {
     const response = await fetch("/api/downloads", { method: "GET" });
     const payload = (await response.json()) as ApiResponse;
     setHistory(payload.records ?? []);
+    setStorageUsage(payload.storageUsage ?? 0);
   }
 
   useEffect(() => {
@@ -186,6 +197,10 @@ export function DownloaderDashboard() {
             <div>
               <span>Failed</span>
               <strong>{failedCount}</strong>
+            </div>
+            <div>
+              <span>Storage Used</span>
+              <strong>{formatBytes(storageUsage)}</strong>
             </div>
           </div>
           <p>

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { getStorageUsage } from "../lib/archive-store";
+import { DataPaths } from "../lib/ytdlp";
+
+describe("getStorageUsage", () => {
+  const testRoot = path.join(process.cwd(), "test-data-storage");
+  const downloadsDir = path.join(testRoot, "downloads");
+
+  const mockPaths: DataPaths = {
+    root: testRoot,
+    downloadsDir: downloadsDir,
+    archiveFile: path.join(testRoot, "archive.txt"),
+    historyFile: path.join(testRoot, "history.json"),
+  };
+
+  beforeEach(async () => {
+    await fs.mkdir(downloadsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it("should return 0 for empty directory", async () => {
+    const size = await getStorageUsage(mockPaths);
+    expect(size).toBe(0);
+  });
+
+  it("should return correct size for single file", async () => {
+    const filePath = path.join(downloadsDir, "test.txt");
+    await fs.writeFile(filePath, "hello", "utf8"); // 5 bytes
+    const size = await getStorageUsage(mockPaths);
+    expect(size).toBe(5);
+  });
+
+  it("should return correct size for nested files", async () => {
+    const subDir = path.join(downloadsDir, "sub");
+    await fs.mkdir(subDir);
+    await fs.writeFile(path.join(downloadsDir, "a.txt"), "A", "utf8"); // 1 byte
+    await fs.writeFile(path.join(subDir, "b.txt"), "BB", "utf8"); // 2 bytes
+
+    const size = await getStorageUsage(mockPaths);
+    expect(size).toBe(3);
+  });
+});


### PR DESCRIPTION
This PR implements the "Display Storage Usage" feature. It calculates the total size of the downloads directory and displays it on the main dashboard so users can monitor their disk usage.

Changes:
- Backend: Added `getStorageUsage` function in `website/lib/archive-store.ts`.
- API: Updated `GET /api/downloads` to include `storageUsage`.
- Frontend: Updated `DownloaderDashboard` to fetch and display the storage usage.
- Tests: Added unit tests for storage calculation.
- Backlog: Created `docs/backlog/open/001_storage_usage.md`.

Verified with unit tests and manual frontend verification using Playwright.

---
*PR created automatically by Jules for task [2028178284294279887](https://jules.google.com/task/2028178284294279887) started by @jjgroenendijk*