### PR TITLE
Display storage usage on dashboard

### DIFF
--- a/docs/backlog/closed/004_display_storage_usage.md
+++ b/docs/backlog/closed/004_display_storage_usage.md
@@ -1,0 +1,7 @@
+# 004 Display Storage Usage
+
+## What
+Display the total storage usage of the downloads directory on the dashboard.
+
+## Why
+Users need to know how much disk space is being consumed by their archived downloads to manage their storage effectively.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -7,6 +7,7 @@ import {
   appendHistory,
   clearHistory,
   ensureDataStorage,
+  getStorageUsage,
   readHistory,
   type DownloadRecord,
 } from "@/lib/archive-store";
@@ -61,8 +62,9 @@ export async function GET() {
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
   const records = await readHistory(paths);
+  const storageUsage = await getStorageUsage(paths.downloadsDir);
 
-  return NextResponse.json({ records });
+  return NextResponse.json({ records, storageUsage });
 }
 
 export async function POST(request: Request) {

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -19,7 +19,20 @@ interface DownloadRecord {
 interface ApiResponse {
   record?: DownloadRecord;
   records?: DownloadRecord[];
+  storageUsage?: number;
   error?: string;
+}
+
+function formatBytes(bytes: number, decimals = 2): string {
+  if (!+bytes) return "0 Bytes";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
 function formatTimestamp(value: string): string {
@@ -35,6 +48,7 @@ export function DownloaderDashboard() {
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
+  const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
   const [feedback, setFeedback] = useState<string>("Idle");
 
@@ -42,6 +56,9 @@ export function DownloaderDashboard() {
     const response = await fetch("/api/downloads", { method: "GET" });
     const payload = (await response.json()) as ApiResponse;
     setHistory(payload.records ?? []);
+    if (payload.storageUsage !== undefined) {
+      setStorageUsage(payload.storageUsage);
+    }
   }
 
   useEffect(() => {
@@ -175,6 +192,10 @@ export function DownloaderDashboard() {
         <aside className="panel stats-panel">
           <h2>Archive Snapshot</h2>
           <div className="stats-grid">
+            <div>
+              <span>Storage Used</span>
+              <strong>{formatBytes(storageUsage)}</strong>
+            </div>
             <div>
               <span>Total Runs</span>
               <strong>{history.length}</strong>

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { getStorageUsage } from "../lib/archive-store";
+
+const TEST_DIR = path.join(__dirname, "temp-test-storage");
+
+describe("getStorageUsage", () => {
+  beforeEach(async () => {
+    await fs.mkdir(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("calculates size of empty directory", async () => {
+    const size = await getStorageUsage(TEST_DIR);
+    expect(size).toBe(0);
+  });
+
+  it("calculates size of directory with files", async () => {
+    await fs.writeFile(path.join(TEST_DIR, "file1.txt"), "hello"); // 5 bytes
+    await fs.writeFile(path.join(TEST_DIR, "file2.txt"), "world"); // 5 bytes
+    const size = await getStorageUsage(TEST_DIR);
+    expect(size).toBe(10);
+  });
+
+  it("calculates size of nested directories", async () => {
+    const subDir = path.join(TEST_DIR, "sub");
+    await fs.mkdir(subDir);
+    await fs.writeFile(path.join(subDir, "file.txt"), "nested"); // 6 bytes
+    await fs.writeFile(path.join(TEST_DIR, "root.txt"), "root"); // 4 bytes
+    const size = await getStorageUsage(TEST_DIR);
+    expect(size).toBe(10);
+  });
+});

--- a/website/tests/home.spec.ts
+++ b/website/tests/home.spec.ts
@@ -6,7 +6,7 @@ test("renders downloader dashboard", async ({ page }) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ records: [] }),
+        body: JSON.stringify({ records: [], storageUsage: 123456789 }),
       });
       return;
     }
@@ -21,6 +21,9 @@ test("renders downloader dashboard", async ({ page }) => {
   await expect(page.getByLabel("Video URL")).toBeVisible();
   await expect(page.getByRole("button", { name: "Download and Archive" })).toBeVisible();
   await expect(page.getByText("No downloads yet.")).toBeVisible();
+
+  await expect(page.getByText("Storage Used")).toBeVisible();
+  await expect(page.getByText("117.74 MB")).toBeVisible();
 });
 
 test("submits a download and displays history", async ({ page }) => {


### PR DESCRIPTION
- Implemented `getStorageUsage` in `website/lib/archive-store.ts`.
- Updated `/api/downloads` to return storage usage.
- Updated `DownloaderDashboard` to display storage usage.
- Added unit tests and Playwright tests.
- Documentation added to `docs/backlog/closed/`.

---
*PR created automatically by Jules for task [6309322142989979321](https://jules.google.com/task/6309322142989979321) started by @jjgroenendijk*