### PR TITLE
feat: display storage usage on dashboard

### DIFF
--- a/docs/backlog/closed/001_storage_usage.md
+++ b/docs/backlog/closed/001_storage_usage.md
@@ -1,0 +1,7 @@
+# Display Storage Usage
+
+## What
+Display the total disk usage of the downloads directory on the dashboard.
+
+## Why
+Users need to know how much space they are using to manage their storage.

--- a/next_output.log
+++ b/next_output.log
@@ -1,0 +1,19 @@
+
+> website@0.1.0 dev
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+
+✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+✓ Ready in 1161ms
+○ Compiling / ...
+ GET / 200 in 4.6s (compile: 4.3s, render: 364ms)
+ GET /api/downloads 200 in 686ms (compile: 665ms, render: 22ms)
+[?25h

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -8,6 +8,7 @@ import {
   clearHistory,
   ensureDataStorage,
   readHistory,
+  getStorageUsage,
   type DownloadRecord,
 } from "@/lib/archive-store";
 import {
@@ -61,8 +62,9 @@ export async function GET() {
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
   const records = await readHistory(paths);
+  const storageUsage = await getStorageUsage(paths.downloadsDir);
 
-  return NextResponse.json({ records });
+  return NextResponse.json({ records, storageUsage });
 }
 
 export async function POST(request: Request) {

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -19,7 +19,16 @@ interface DownloadRecord {
 interface ApiResponse {
   record?: DownloadRecord;
   records?: DownloadRecord[];
+  storageUsage?: number;
   error?: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }
 
 function formatTimestamp(value: string): string {
@@ -35,6 +44,7 @@ export function DownloaderDashboard() {
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
+  const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
   const [feedback, setFeedback] = useState<string>("Idle");
 
@@ -42,6 +52,7 @@ export function DownloaderDashboard() {
     const response = await fetch("/api/downloads", { method: "GET" });
     const payload = (await response.json()) as ApiResponse;
     setHistory(payload.records ?? []);
+    setStorageUsage(payload.storageUsage ?? 0);
   }
 
   useEffect(() => {
@@ -178,6 +189,10 @@ export function DownloaderDashboard() {
             <div>
               <span>Total Runs</span>
               <strong>{history.length}</strong>
+            </div>
+            <div>
+              <span>Storage Used</span>
+              <strong>{formatBytes(storageUsage)}</strong>
             </div>
             <div>
               <span>Completed</span>

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 
 import { type DataPaths } from "./ytdlp";
 
@@ -65,4 +66,24 @@ export async function appendHistory(
 
   const limited = history.slice(0, 200);
   await fs.writeFile(paths.historyFile, `${JSON.stringify(limited, null, 2)}\n`, "utf8");
+}
+
+export async function getStorageUsage(dirPath: string): Promise<number> {
+  let totalSize = 0;
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        totalSize += await getStorageUsage(fullPath);
+      } else if (entry.isFile()) {
+        const stats = await fs.stat(fullPath);
+        totalSize += stats.size;
+      }
+    }
+  } catch {
+    // Ignore errors (e.g. directory not found)
+  }
+  return totalSize;
 }

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { getStorageUsage } from "../lib/archive-store";
+
+const TEST_DIR = path.join(__dirname, "test-storage");
+
+describe("getStorageUsage", () => {
+  beforeEach(async () => {
+    await fs.mkdir(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("should return 0 for empty directory", async () => {
+    const size = await getStorageUsage(TEST_DIR);
+    expect(size).toBe(0);
+  });
+
+  it("should calculate size of files in directory", async () => {
+    await fs.writeFile(path.join(TEST_DIR, "file1.txt"), "hello"); // 5 bytes
+    await fs.writeFile(path.join(TEST_DIR, "file2.txt"), "world"); // 5 bytes
+    const size = await getStorageUsage(TEST_DIR);
+    expect(size).toBe(10);
+  });
+
+  it("should calculate size recursively", async () => {
+    const subDir = path.join(TEST_DIR, "sub");
+    await fs.mkdir(subDir);
+    await fs.writeFile(path.join(subDir, "file3.txt"), "test"); // 4 bytes
+    const size = await getStorageUsage(TEST_DIR);
+    expect(size).toBe(4);
+  });
+});


### PR DESCRIPTION
Implements the "Display Storage Usage" feature by adding recursive directory size calculation to the backend and displaying it in the dashboard UI.
- Implements recursive `getStorageUsage` in `website/lib/archive-store.ts`.
- Updates `website/app/api/downloads/route.ts` to include `storageUsage` in the response.
- Updates `website/components/downloader-dashboard.tsx` to fetch and display the storage usage.
- Adds unit tests in `website/tests/archive-store.test.ts`.
- Verifies UI with Playwright script (verified locally).

---
*PR created automatically by Jules for task [16148819052583853563](https://jules.google.com/task/16148819052583853563) started by @jjgroenendijk*