### PR TITLE
feat: display storage usage on dashboard

### DIFF
--- a/docs/backlog/open/001_storage_usage.md
+++ b/docs/backlog/open/001_storage_usage.md
@@ -1,0 +1,12 @@
+# Display Storage Usage
+
+## What
+Display the total disk usage of the downloads directory on the dashboard. This should include all files within the configured downloads directory, recursively.
+
+## Why
+Users need to know how much disk space is being consumed by downloaded videos and archives to manage their storage effectively, especially when running on limited disk space or shared volumes.
+
+## Acceptance Criteria
+- The dashboard displays the total size of the downloads folder.
+- The size is formatted in human-readable units (e.g., KB, MB, GB).
+- The value updates when the page is refreshed or history is reloaded.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -7,6 +7,7 @@ import {
   appendHistory,
   clearHistory,
   ensureDataStorage,
+  getStorageUsage,
   readHistory,
   type DownloadRecord,
 } from "@/lib/archive-store";
@@ -61,8 +62,9 @@ export async function GET() {
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
   const records = await readHistory(paths);
+  const storageUsage = await getStorageUsage(paths);
 
-  return NextResponse.json({ records });
+  return NextResponse.json({ records, storageUsage });
 }
 
 export async function POST(request: Request) {

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -19,6 +19,7 @@ interface DownloadRecord {
 interface ApiResponse {
   record?: DownloadRecord;
   records?: DownloadRecord[];
+  storageUsage?: number;
   error?: string;
 }
 
@@ -30,11 +31,20 @@ function formatTimestamp(value: string): string {
   }
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
+  const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
   const [feedback, setFeedback] = useState<string>("Idle");
 
@@ -42,6 +52,7 @@ export function DownloaderDashboard() {
     const response = await fetch("/api/downloads", { method: "GET" });
     const payload = (await response.json()) as ApiResponse;
     setHistory(payload.records ?? []);
+    setStorageUsage(payload.storageUsage ?? 0);
   }
 
   useEffect(() => {
@@ -186,6 +197,10 @@ export function DownloaderDashboard() {
             <div>
               <span>Failed</span>
               <strong>{failedCount}</strong>
+            </div>
+            <div>
+              <span>Storage Usage</span>
+              <strong>{formatBytes(storageUsage)}</strong>
             </div>
           </div>
           <p>

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { getStorageUsage } from "../lib/archive-store";
+import { type DataPaths } from "../lib/ytdlp";
+
+vi.mock("node:fs/promises");
+
+describe("getStorageUsage", () => {
+  const mockPaths: DataPaths = {
+    root: "/data",
+    downloadsDir: "/data/downloads",
+    archiveFile: "/data/download-archive.txt",
+    historyFile: "/data/history.json",
+  };
+
+  it("should calculate total size of files in directory", async () => {
+    // Mock fs.readdir to return some files
+    vi.mocked(fs.readdir).mockImplementation(async (dirPath, options) => {
+      if (dirPath === "/data/downloads") {
+        return [
+          { name: "file1.mp4", isDirectory: () => false },
+          { name: "file2.mp3", isDirectory: () => false },
+        ] as any;
+      }
+      return [] as any;
+    });
+
+    // Mock fs.stat to return sizes
+    vi.mocked(fs.stat).mockImplementation(async (filePath) => {
+        // Normalize path for cross-platform test consistency if needed,
+        // but exact match is fine here for mock
+        if (filePath.endsWith("file1.mp4")) {
+            return { size: 1024 } as any;
+        }
+        if (filePath.endsWith("file2.mp3")) {
+            return { size: 2048 } as any;
+        }
+        return { size: 0 } as any;
+    });
+
+    // Mock ensureDataStorage to do nothing
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+
+    const size = await getStorageUsage(mockPaths);
+    expect(size).toBe(1024 + 2048);
+  });
+
+    it("should handle nested directories recursively", async () => {
+    // Mock fs.readdir to return nested structure
+    vi.mocked(fs.readdir).mockImplementation(async (dirPath, options) => {
+      // Basic check if it's the downloads dir
+      if (typeof dirPath === 'string' && dirPath.endsWith("/downloads")) {
+        return [
+          { name: "folder1", isDirectory: () => true },
+          { name: "file1.txt", isDirectory: () => false },
+        ] as any;
+      }
+      if (typeof dirPath === 'string' && dirPath.endsWith("folder1")) {
+           return [
+          { name: "file2.txt", isDirectory: () => false },
+        ] as any;
+      }
+      return [] as any;
+    });
+
+    // Mock fs.stat to return sizes
+    vi.mocked(fs.stat).mockImplementation(async (filePath) => {
+        if (typeof filePath === 'string' && filePath.endsWith("file1.txt")) {
+            return { size: 100 } as any;
+        }
+        if (typeof filePath === 'string' && filePath.endsWith("file2.txt")) {
+            return { size: 200 } as any;
+        }
+        return { size: 0 } as any;
+    });
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+
+    const size = await getStorageUsage(mockPaths);
+    expect(size).toBe(100 + 200);
+  });
+
+  it("should return 0 if directory is empty", async () => {
+     vi.mocked(fs.readdir).mockImplementation(async (dirPath, options) => {
+      return [] as any;
+    });
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+
+    const size = await getStorageUsage(mockPaths);
+    expect(size).toBe(0);
+  });
+});


### PR DESCRIPTION
Implemented a feature to display the total disk usage of the downloads directory on the dashboard. This allows users to monitor their storage consumption directly from the web interface.

The implementation includes:
- A new `getStorageUsage` function that recursively calculates directory size.
- An update to the `/api/downloads` endpoint to include storage usage in the response.
- A UI update to the `DownloaderDashboard` to display the usage in human-readable format.
- Comprehensive unit tests for the storage calculation logic.


---
*PR created automatically by Jules for task [1602258684953974319](https://jules.google.com/task/1602258684953974319) started by @jjgroenendijk*