### PR TITLE
Add nightly PR reconciliation and Jules session recovery

### DIFF
--- a/.github/scripts/reconcile_prs.py
+++ b/.github/scripts/reconcile_prs.py
@@ -1,0 +1,465 @@
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+PASSING_CHECK_STATES = {"SUCCESS", "PASS", "SKIPPED", "SKIP", "NEUTRAL"}
+SESSION_ID_PATTERN = re.compile(r"\*\*Session ID:\*\* `(sessions/[^`]+)`")
+
+
+@dataclass
+class ReconcileStats:
+    scanned: int = 0
+    merged: int = 0
+    issues_created: int = 0
+    sessions_triggered: int = 0
+    errors: int = 0
+
+
+class GitHubCLI:
+    def __init__(self, repo: str, dry_run: bool = False):
+        self.repo = repo
+        self.dry_run = dry_run
+        self._issues_cache = None
+
+    def run(self, command: list[str], check: bool = True):
+        result = subprocess.run(command, capture_output=True, text=True)
+        if check and result.returncode != 0:
+            printable = " ".join(command)
+            print(f"Command failed: {printable}")
+            if result.stderr:
+                print(result.stderr.strip())
+            return None
+        return result
+
+    def run_json(self, command: list[str]):
+        result = self.run(command, check=True)
+        if result is None:
+            return None
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            return None
+
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            printable = " ".join(command)
+            print(f"Failed to decode JSON output: {printable}")
+            return None
+
+    def list_open_pr_numbers(self):
+        data = self.run_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number",
+            ]
+        )
+        if not data:
+            return []
+        return [int(pr["number"]) for pr in data]
+
+    def get_pr(self, pr_number: int):
+        return self.run_json(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                self.repo,
+                "--json",
+                "number,title,url,mergeable,isDraft,state",
+            ]
+        )
+
+    def get_pr_checks(self, pr_number: int):
+        result = self.run(
+            [
+                "gh",
+                "pr",
+                "checks",
+                str(pr_number),
+                "--repo",
+                self.repo,
+                "--json",
+                "name,state,link",
+            ],
+            check=False,
+        )
+        if result is None:
+            return []
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            return []
+
+        try:
+            checks = json.loads(stdout)
+        except json.JSONDecodeError:
+            return []
+
+        if isinstance(checks, list):
+            return checks
+        return []
+
+    def merge_pr(self, pr_number: int):
+        if self.dry_run:
+            print(f"[dry-run] Would merge PR #{pr_number}")
+            return True
+
+        # Approval is best-effort; some repos do not allow bot approvals.
+        self.run(
+            [
+                "gh",
+                "pr",
+                "review",
+                str(pr_number),
+                "--repo",
+                self.repo,
+                "--approve",
+            ],
+            check=False,
+        )
+
+        result = self.run(
+            [
+                "gh",
+                "pr",
+                "merge",
+                str(pr_number),
+                "--repo",
+                self.repo,
+                "--merge",
+                "--delete-branch",
+            ],
+            check=False,
+        )
+        return bool(result and result.returncode == 0)
+
+    def _list_open_issues(self):
+        if self._issues_cache is not None:
+            return self._issues_cache
+
+        data = self.run_json(["gh", "api", f"repos/{self.repo}/issues?state=open&per_page=100"])
+        if not isinstance(data, list):
+            self._issues_cache = []
+            return self._issues_cache
+
+        self._issues_cache = [issue for issue in data if "pull_request" not in issue]
+        return self._issues_cache
+
+    def find_open_issue_by_title(self, title: str):
+        for issue in self._list_open_issues():
+            if issue.get("title") == title:
+                return int(issue["number"])
+        return None
+
+    def create_issue(self, title: str, body: str):
+        if self.dry_run:
+            print(f"[dry-run] Would create issue: {title}")
+            return 0
+
+        result = self.run(
+            [
+                "gh",
+                "api",
+                f"repos/{self.repo}/issues",
+                "-X",
+                "POST",
+                "-f",
+                f"title={title}",
+                "-f",
+                f"body={body}",
+                "-q",
+                ".number",
+            ],
+            check=True,
+        )
+        if result is None:
+            return None
+
+        issue_number_text = result.stdout.strip()
+        if not issue_number_text.isdigit():
+            return None
+
+        issue_number = int(issue_number_text)
+        if self._issues_cache is not None:
+            self._issues_cache.append({"number": issue_number, "title": title})
+        return issue_number
+
+    def issue_has_jules_session(self, issue_number: int):
+        comments = self.run_json(
+            [
+                "gh",
+                "api",
+                f"repos/{self.repo}/issues/{issue_number}/comments?per_page=100",
+            ]
+        )
+        if not isinstance(comments, list):
+            return False
+
+        for comment in comments:
+            body = comment.get("body", "")
+            if SESSION_ID_PATTERN.search(body):
+                return True
+        return False
+
+    def trigger_jules_session(self, issue_number: int):
+        if self.dry_run:
+            print(f"[dry-run] Would trigger run-agent.yml for issue #{issue_number}")
+            return True
+
+        result = self.run(
+            [
+                "gh",
+                "workflow",
+                "run",
+                "run-agent.yml",
+                "--repo",
+                self.repo,
+                "-f",
+                f"issue_number={issue_number}",
+            ],
+            check=False,
+        )
+        return bool(result and result.returncode == 0)
+
+
+def issue_title_for_pr(pr_number: int):
+    return f"PR Automation: PR #{pr_number} requires attention"
+
+
+def normalize_check_state(check: dict):
+    return str(check.get("state") or "UNKNOWN").upper()
+
+
+def is_passing_check_state(state: str):
+    return state.upper() in PASSING_CHECK_STATES
+
+
+def blocking_checks(checks: list[dict]):
+    blocked = []
+    for check in checks:
+        state = normalize_check_state(check)
+        if not is_passing_check_state(state):
+            blocked.append(check)
+    return blocked
+
+
+def summarize_blocking_checks(checks: list[dict]):
+    lines = []
+    for check in checks:
+        name = check.get("name", "(unnamed check)")
+        state = normalize_check_state(check)
+        lines.append(f"- `{name}`: `{state}`")
+    return "\n".join(lines)
+
+
+def build_issue_body(pr: dict, reasons: list[str], blocked: list[dict]):
+    lines = [
+        f"Automated PR reconciliation detected blockers for PR #{pr['number']}.",
+        "",
+        f"PR: {pr.get('url', '(missing url)')}",
+        "",
+        "## Blockers",
+    ]
+
+    for reason in reasons:
+        lines.append(f"- {reason}")
+
+    if blocked:
+        lines.extend(["", "## Non-passing checks", summarize_blocking_checks(blocked)])
+
+    lines.extend(
+        [
+            "",
+            "Please resolve the blockers. A Jules session should handle this issue.",
+            f"<!-- pr-automation:pr={pr['number']} -->",
+        ]
+    )
+    return "\n".join(lines)
+
+
+class PrReconciler:
+    def __init__(self, client: GitHubCLI):
+        self.client = client
+        self.stats = ReconcileStats()
+
+    def reconcile(self, pr_numbers: list[int] | None = None):
+        numbers = pr_numbers or self.client.list_open_pr_numbers()
+        if not numbers:
+            print("No open PRs to process.")
+            return self.stats
+
+        for pr_number in numbers:
+            self.reconcile_pr(pr_number)
+
+        return self.stats
+
+    def _resolve_mergeable(self, pr_number: int, initial_state: str):
+        mergeable = (initial_state or "UNKNOWN").upper()
+        if mergeable != "UNKNOWN":
+            return mergeable
+
+        for _ in range(3):
+            time.sleep(2)
+            refreshed = self.client.get_pr(pr_number)
+            if not refreshed:
+                break
+            mergeable = str(refreshed.get("mergeable") or "UNKNOWN").upper()
+            if mergeable != "UNKNOWN":
+                return mergeable
+
+        return mergeable
+
+    def _ensure_issue_and_session(self, pr: dict, reasons: list[str], blocked: list[dict]):
+        title = issue_title_for_pr(int(pr["number"]))
+        issue_number = self.client.find_open_issue_by_title(title)
+        created_new_issue = False
+
+        if issue_number is None:
+            body = build_issue_body(pr, reasons, blocked)
+            issue_number = self.client.create_issue(title, body)
+            if issue_number is None:
+                print(f"Failed to create issue for PR #{pr['number']}")
+                self.stats.errors += 1
+                return
+            created_new_issue = True
+            self.stats.issues_created += 1
+            print(f"Created issue #{issue_number} for PR #{pr['number']}")
+
+        if created_new_issue:
+            print(
+                f"Issue #{issue_number} is new. Skipping manual Jules trigger to avoid duplicate sessions from issue-open events."
+            )
+            return
+
+        if self.client.issue_has_jules_session(issue_number):
+            print(f"Issue #{issue_number} already has a Jules session.")
+            return
+
+        print(f"Issue #{issue_number} has no Jules session. Triggering run-agent workflow.")
+        if self.client.trigger_jules_session(issue_number):
+            self.stats.sessions_triggered += 1
+            return
+
+        print(f"Failed to trigger Jules for issue #{issue_number}")
+        self.stats.errors += 1
+
+    def reconcile_pr(self, pr_number: int):
+        self.stats.scanned += 1
+        pr = self.client.get_pr(pr_number)
+        if not pr:
+            print(f"Unable to load PR #{pr_number}")
+            self.stats.errors += 1
+            return
+
+        if pr.get("state") != "OPEN":
+            print(f"PR #{pr_number} is {pr.get('state')}. Skipping.")
+            return
+
+        mergeable = self._resolve_mergeable(pr_number, str(pr.get("mergeable") or "UNKNOWN"))
+        checks = self.client.get_pr_checks(pr_number)
+        blocked = blocking_checks(checks)
+
+        reasons = []
+        if str(mergeable).upper() == "CONFLICTING":
+            reasons.append("Merge conflict detected.")
+
+        if blocked:
+            reasons.append("PR checks are not passing.")
+
+        if reasons:
+            self._ensure_issue_and_session(pr, reasons, blocked)
+            return
+
+        if self.client.merge_pr(pr_number):
+            self.stats.merged += 1
+            print(f"Merged PR #{pr_number}")
+            return
+
+        print(f"Merge failed for PR #{pr_number}; collecting diagnostics.")
+        refreshed_pr = self.client.get_pr(pr_number) or pr
+        refreshed_mergeable = self._resolve_mergeable(
+            pr_number, str(refreshed_pr.get("mergeable") or "UNKNOWN")
+        )
+        refreshed_checks = self.client.get_pr_checks(pr_number)
+        refreshed_blocked = blocking_checks(refreshed_checks)
+
+        fallback_reasons = []
+        if str(refreshed_mergeable).upper() == "CONFLICTING":
+            fallback_reasons.append("Merge conflict detected after merge attempt.")
+        if refreshed_blocked:
+            fallback_reasons.append("PR checks are not passing after merge attempt.")
+        if not fallback_reasons:
+            fallback_reasons.append("Automatic merge failed for an unknown reason.")
+
+        self._ensure_issue_and_session(refreshed_pr, fallback_reasons, refreshed_blocked)
+
+
+def resolve_repo(args_repo: str | None):
+    if args_repo:
+        return args_repo
+
+    from_env = os.environ.get("GITHUB_REPOSITORY")
+    if from_env:
+        return from_env
+
+    result = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+
+    return None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Reconcile open PRs and recover Jules sessions.")
+    parser.add_argument("--pr-number", type=int, help="Optional single PR number to reconcile")
+    parser.add_argument("--repo", help="GitHub repo in owner/name format")
+    parser.add_argument("--dry-run", action="store_true", help="Print intended changes only")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo = resolve_repo(args.repo)
+    if not repo:
+        print("Could not resolve repository. Set --repo or GITHUB_REPOSITORY.")
+        return 1
+
+    client = GitHubCLI(repo=repo, dry_run=args.dry_run)
+    reconciler = PrReconciler(client)
+
+    pr_numbers = [args.pr_number] if args.pr_number else None
+    stats = reconciler.reconcile(pr_numbers)
+
+    print(
+        "Summary: "
+        f"scanned={stats.scanned}, merged={stats.merged}, "
+        f"issues_created={stats.issues_created}, sessions_triggered={stats.sessions_triggered}, "
+        f"errors={stats.errors}"
+    )
+
+    return 1 if stats.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/nightly-pr-reconciliation.yml
+++ b/.github/workflows/nightly-pr-reconciliation.yml
@@ -1,0 +1,30 @@
+name: Nightly PR Reconciliation
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-pr-reconciliation
+  cancel-in-progress: false
+
+jobs:
+  reconcile-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Reconcile open PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 .github/scripts/reconcile_prs.py

--- a/README.md
+++ b/README.md
@@ -63,4 +63,5 @@ The app will be available on `http://localhost:3000`.
 ## CI/CD
 
 - `Verify Codebase` runs Python lint/tests and website lint/unit/e2e tests.
+- `Nightly PR Reconciliation` runs every midnight UTC to merge healthy open PRs, create issues for blocked PRs, and recover missing Jules sessions.
 - `Publish Container` builds and publishes the single runtime image to GHCR.

--- a/docs/backlog/closed/002_pr_reconciliation_autonomy.md
+++ b/docs/backlog/closed/002_pr_reconciliation_autonomy.md
@@ -1,0 +1,18 @@
+# Implement Nightly PR Reconciliation + Jules Recovery
+
+## What
+Create a scheduled GitHub Action that reconciles all open PRs nightly:
+- Merge PRs that are mergeable and have passing checks.
+- Create or reuse an issue when a PR has merge conflicts or non-passing checks.
+- Ensure a Jules session exists for that issue, and trigger one when missing.
+
+## Why
+Current automation is event-driven and can miss edge cases. A nightly reconciliation pass provides recovery and keeps autonomous development moving.
+
+## Progress
+- [x] Open backlog item for PR reconciliation automation.
+- [x] Implement reconciliation script for PR merge/check/conflict/session handling.
+- [x] Add nightly scheduled workflow (midnight UTC) and manual trigger.
+- [x] Add unit tests for reconciliation decision logic.
+- [x] Update README/docs with the new automation behavior.
+- [x] Validate with local test run and prepare PR.

--- a/tests/test_reconcile_prs.py
+++ b/tests/test_reconcile_prs.py
@@ -1,0 +1,136 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "reconcile_prs.py"
+SPEC = spec_from_file_location("reconcile_prs", MODULE_PATH)
+reconcile_prs = module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(reconcile_prs)
+
+
+class FakeClient:
+    def __init__(
+        self,
+        pr,
+        checks,
+        merge_result=False,
+        existing_issue=None,
+        has_session=False,
+    ):
+        self.pr = pr
+        self.checks = checks
+        self.merge_result = merge_result
+        self.existing_issue = existing_issue
+        self.has_session = has_session
+
+        self.merged = []
+        self.created_issues = []
+        self.triggered_sessions = []
+
+    def list_open_pr_numbers(self):
+        return [self.pr["number"]]
+
+    def get_pr(self, pr_number):
+        if pr_number != self.pr["number"]:
+            return None
+        return self.pr
+
+    def get_pr_checks(self, pr_number):
+        return self.checks
+
+    def merge_pr(self, pr_number):
+        self.merged.append(pr_number)
+        return self.merge_result
+
+    def find_open_issue_by_title(self, title):
+        return self.existing_issue
+
+    def create_issue(self, title, body):
+        self.created_issues.append((title, body))
+        return 999
+
+    def issue_has_jules_session(self, issue_number):
+        return self.has_session
+
+    def trigger_jules_session(self, issue_number):
+        self.triggered_sessions.append(issue_number)
+        return True
+
+
+def test_blocking_checks_detects_non_passing_states():
+    checks = [
+        {"name": "lint", "state": "SUCCESS"},
+        {"name": "tests", "state": "FAILURE"},
+        {"name": "e2e", "state": "PENDING"},
+    ]
+
+    blocked = reconcile_prs.blocking_checks(checks)
+
+    assert [check["name"] for check in blocked] == ["tests", "e2e"]
+
+
+def test_conflicting_pr_creates_issue():
+    client = FakeClient(
+        pr={
+            "number": 42,
+            "title": "Fix downloader",
+            "url": "https://example/pr/42",
+            "mergeable": "CONFLICTING",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[],
+        existing_issue=None,
+    )
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(42)
+
+    assert reconciler.stats.issues_created == 1
+    assert client.created_issues
+    assert not client.triggered_sessions
+
+
+def test_existing_issue_without_session_triggers_jules():
+    client = FakeClient(
+        pr={
+            "number": 7,
+            "title": "Refactor",
+            "url": "https://example/pr/7",
+            "mergeable": "MERGEABLE",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[{"name": "ci", "state": "FAILURE"}],
+        existing_issue=123,
+        has_session=False,
+    )
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(7)
+
+    assert reconciler.stats.sessions_triggered == 1
+    assert client.triggered_sessions == [123]
+
+
+def test_mergeable_and_passing_pr_is_merged():
+    client = FakeClient(
+        pr={
+            "number": 9,
+            "title": "Improve docs",
+            "url": "https://example/pr/9",
+            "mergeable": "MERGEABLE",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[{"name": "ci", "state": "SUCCESS"}],
+        merge_result=True,
+    )
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(9)
+
+    assert reconciler.stats.merged == 1
+    assert client.merged == [9]
+    assert not client.created_issues


### PR DESCRIPTION
## Summary
- add `.github/workflows/nightly-pr-reconciliation.yml` to run every midnight UTC and on manual dispatch
- add `.github/scripts/reconcile_prs.py` to:
  - scan open PRs
  - merge PRs that are open, mergeable, and with passing checks
  - create/reuse a blocker issue when PRs are conflicting or have non-passing checks
  - trigger `run-agent.yml` only when an existing blocker issue has no Jules session comment
- add unit tests for reconciliation logic in `tests/test_reconcile_prs.py`
- update README and close backlog item `002_pr_reconciliation_autonomy`

## Validation
- `uv run ruff check .`
- `uv run pytest`
