### PR TITLE
feat: allow deleting individual download records

### DIFF
--- a/docs/backlog/closed/001_delete_individual_record.md
+++ b/docs/backlog/closed/001_delete_individual_record.md
@@ -1,0 +1,7 @@
+# Delete Individual Download Records
+
+## What
+Allow users to delete individual download records from the history list. This action should also remove the associated downloaded files from the disk.
+
+## Why
+Currently, users can only clear the entire history. This is inconvenient if they want to remove a single failed download or free up space by deleting specific large files while keeping others.

--- a/website/app/api/downloads/[id]/route.ts
+++ b/website/app/api/downloads/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { deleteRecord } from "@/lib/archive-store";
+import { getDataPaths, resolveDataDir } from "@/lib/ytdlp";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function DELETE(
+  request: Request,
+  props: { params: Promise<{ id: string }> },
+) {
+  const { id } = await props.params;
+
+  const dataDir = resolveDataDir();
+  const paths = getDataPaths(dataDir);
+
+  const deleted = await deleteRecord(paths, id);
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Record not found." }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -252,6 +252,21 @@ button:disabled {
   background: rgba(47, 199, 161, 0.1);
 }
 
+.delete-btn {
+  margin-left: 0.5rem;
+  width: auto;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  background: transparent;
+  color: var(--fail);
+  border: 1px solid rgba(255, 115, 115, 0.4);
+  border-radius: 6px;
+}
+
+.delete-btn:hover {
+  background: rgba(255, 115, 115, 0.1);
+}
+
 .url-line {
   margin: 0.45rem 0;
   font-size: 0.9rem;

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -136,6 +136,29 @@ export function DownloaderDashboard() {
     }
   }
 
+  async function handleDelete(id: string) {
+    if (
+      !confirm(
+        "Are you sure you want to delete this record? This cannot be undone.",
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/downloads/${id}`, { method: "DELETE" });
+      if (response.ok) {
+        setFeedback("Record deleted.");
+        setHistory((prev) => prev.filter((r) => r.id !== id));
+        void loadHistory();
+      } else {
+        setFeedback("Failed to delete record.");
+      }
+    } catch {
+      setFeedback("Error deleting record.");
+    }
+  }
+
   return (
     <main className="page-shell">
       <section className="hero-card">
@@ -239,6 +262,14 @@ export function DownloaderDashboard() {
                     title="Retry this download"
                   >
                     Retry
+                  </button>
+                  <button
+                    type="button"
+                    className="delete-btn"
+                    onClick={() => handleDelete(record.id)}
+                    title="Delete this record"
+                  >
+                    Delete
                   </button>
                 </header>
                 <p className="url-line">{record.url}</p>

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -2,20 +2,20 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
-import { getStorageUsage } from "../lib/archive-store";
+import { getStorageUsage, deleteRecord, appendHistory, DownloadRecord } from "../lib/archive-store";
 import { DataPaths } from "../lib/ytdlp";
 
+const testRoot = path.join(process.cwd(), "test-data-storage");
+const downloadsDir = path.join(testRoot, "downloads");
+
+const mockPaths: DataPaths = {
+  root: testRoot,
+  downloadsDir: downloadsDir,
+  archiveFile: path.join(testRoot, "archive.txt"),
+  historyFile: path.join(testRoot, "history.json"),
+};
+
 describe("getStorageUsage", () => {
-  const testRoot = path.join(process.cwd(), "test-data-storage");
-  const downloadsDir = path.join(testRoot, "downloads");
-
-  const mockPaths: DataPaths = {
-    root: testRoot,
-    downloadsDir: downloadsDir,
-    archiveFile: path.join(testRoot, "archive.txt"),
-    historyFile: path.join(testRoot, "history.json"),
-  };
-
   beforeEach(async () => {
     await fs.mkdir(downloadsDir, { recursive: true });
   });
@@ -44,5 +44,100 @@ describe("getStorageUsage", () => {
 
     const size = await getStorageUsage(mockPaths);
     expect(size).toBe(3);
+  });
+});
+
+describe("deleteRecord", () => {
+  beforeEach(async () => {
+    await fs.mkdir(downloadsDir, { recursive: true });
+    // Initialize history file
+    await fs.writeFile(mockPaths.historyFile, "[]\n", "utf8");
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it("should delete record and associated files", async () => {
+    const file1 = "video.mp4";
+    const file2 = "thumb.jpg";
+    await fs.writeFile(path.join(downloadsDir, file1), "video data");
+    await fs.writeFile(path.join(downloadsDir, file2), "thumb data");
+
+    const record: DownloadRecord = {
+      id: "test-id",
+      createdAt: new Date().toISOString(),
+      url: "http://example.com",
+      mode: "video",
+      includePlaylist: false,
+      status: "completed",
+      files: [file1, file2],
+      logTail: "",
+    };
+
+    await appendHistory(mockPaths, record);
+
+    const result = await deleteRecord(mockPaths, "test-id");
+    expect(result).toBe(true);
+
+    // Verify files are gone
+    await expect(fs.access(path.join(downloadsDir, file1))).rejects.toThrow();
+    await expect(fs.access(path.join(downloadsDir, file2))).rejects.toThrow();
+
+    // Verify history is updated
+    const historyContent = await fs.readFile(mockPaths.historyFile, "utf8");
+    const history = JSON.parse(historyContent);
+    expect(history).toHaveLength(0);
+  });
+
+  it("should return false if record not found", async () => {
+    const result = await deleteRecord(mockPaths, "non-existent-id");
+    expect(result).toBe(false);
+  });
+
+  it("should delete record even if files are missing", async () => {
+     const record: DownloadRecord = {
+      id: "test-id-missing-files",
+      createdAt: new Date().toISOString(),
+      url: "http://example.com",
+      mode: "video",
+      includePlaylist: false,
+      status: "completed",
+      files: ["missing.mp4"],
+      logTail: "",
+    };
+
+    await appendHistory(mockPaths, record);
+
+    const result = await deleteRecord(mockPaths, "test-id-missing-files");
+    expect(result).toBe(true);
+
+    const historyContent = await fs.readFile(mockPaths.historyFile, "utf8");
+    const history = JSON.parse(historyContent);
+    expect(history).toHaveLength(0);
+  });
+
+  it("should not delete files outside of downloads directory", async () => {
+      const outsideFile = path.join(testRoot, "outside.txt");
+      await fs.writeFile(outsideFile, "secret");
+
+      const record: DownloadRecord = {
+      id: "malicious-id",
+      createdAt: new Date().toISOString(),
+      url: "http://example.com",
+      mode: "video",
+      includePlaylist: false,
+      status: "completed",
+      files: ["../outside.txt"],
+      logTail: "",
+    };
+
+    await appendHistory(mockPaths, record);
+
+    const result = await deleteRecord(mockPaths, "malicious-id");
+    expect(result).toBe(true); // Record deleted
+
+    // File should still exist
+    await expect(fs.access(outsideFile)).resolves.toBeUndefined();
   });
 });

--- a/website/tests/delete_record.spec.ts
+++ b/website/tests/delete_record.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test('should delete individual record', async ({ page }) => {
+  let historyRecords = [
+    {
+      id: '1',
+      createdAt: new Date().toISOString(),
+      url: 'https://youtube.com/watch?v=123',
+      mode: 'video',
+      includePlaylist: false,
+      status: 'completed',
+      files: ['video.mp4'],
+      logTail: 'done'
+    }
+  ];
+
+  // Mock API behavior for GET
+  await page.route('**/api/downloads', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        json: {
+          records: historyRecords,
+          storageUsage: 1024
+        }
+      });
+    } else {
+        await route.continue();
+    }
+  });
+
+  // Mock API behavior for DELETE individual record
+  await page.route('**/api/downloads/1', async route => {
+      if (route.request().method() === 'DELETE') {
+          historyRecords = []; // Update mock state
+          await route.fulfill({ json: { success: true } });
+      } else {
+          await route.continue();
+      }
+  });
+
+  await page.goto('/');
+
+  // Verify history item is present
+  const item = page.locator('.history-item').first();
+  await expect(item).toBeVisible();
+  await expect(item.getByText('video.mp4')).toBeVisible();
+
+  // Setup dialog handler
+  page.on('dialog', dialog => dialog.accept());
+
+  // Click Delete button
+  await item.getByRole('button', { name: 'Delete' }).click();
+
+  // Verify history item is removed
+  // The UI updates optimistically AND reloads history.
+  // We expect "No downloads yet." because the list is empty.
+  await expect(page.getByText('No downloads yet.')).toBeVisible();
+});


### PR DESCRIPTION
This PR implements the ability for users to delete individual download records from the history dashboard. It includes backend logic to safely delete files and update the history, a new API endpoint, and frontend UI updates. It also includes comprehensive unit and E2E tests.

---
*PR created automatically by Jules for task [1714839707188837610](https://jules.google.com/task/1714839707188837610) started by @jjgroenendijk*