### PR TITLE
Fix lint error in website/app/api/files/[...path]/route.ts

### DIFF
--- a/website/app/api/files/[...path]/route.ts
+++ b/website/app/api/files/[...path]/route.ts
@@ -53,8 +53,8 @@ export async function GET(
         "Content-Length": stat.size.toString(),
       },
     });
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
     console.error("File download error:", error);


### PR DESCRIPTION
Replaced explicit "any" type in catch block with "NodeJS.ErrnoException" casting to satisfy "@typescript-eslint/no-explicit-any" rule while maintaining "ENOENT" error handling.

---
*PR created automatically by Jules for task [4243708379334131294](https://jules.google.com/task/4243708379334131294) started by @jjgroenendijk*