### PR TITLE
Fix lint error: unexpected any in file route

### DIFF
--- a/website/app/api/files/[...path]/route.ts
+++ b/website/app/api/files/[...path]/route.ts
@@ -53,8 +53,8 @@ export async function GET(
         "Content-Length": stat.size.toString(),
       },
     });
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
+  } catch (error: unknown) {
+    if (error instanceof Error && (error as { code?: string }).code === 'ENOENT') {
       return NextResponse.json({ error: "File not found" }, { status: 404 });
     }
     console.error("File download error:", error);


### PR DESCRIPTION
Replaces `any` type in catch block with `unknown` and safe type checking in `website/app/api/files/[...path]/route.ts`.
This fixes the CI lint error `@typescript-eslint/no-explicit-any`.

---
*PR created automatically by Jules for task [11477171749224267241](https://jules.google.com/task/11477171749224267241) started by @jjgroenendijk*