### PR TITLE
feat: Add delete functionality for download history

### DIFF
--- a/website/app/api/downloads/[id]/route.ts
+++ b/website/app/api/downloads/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { deleteRecord, ensureDataStorage } from "@/lib/archive-store";
+import { getDataPaths, resolveDataDir } from "@/lib/ytdlp";
+
+export const runtime = "nodejs";
+
+export async function DELETE(
+  request: Request,
+  props: { params: Promise<{ id: string }> },
+) {
+  const params = await props.params;
+  const { id } = params;
+
+  if (!id) {
+    return NextResponse.json({ error: "ID is required" }, { status: 400 });
+  }
+
+  const dataDir = resolveDataDir();
+  const paths = getDataPaths(dataDir);
+  await ensureDataStorage(paths);
+
+  const success = await deleteRecord(paths, id);
+
+  if (!success) {
+    return NextResponse.json({ error: "Record not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -252,6 +252,21 @@ button:disabled {
   background: rgba(47, 199, 161, 0.1);
 }
 
+.delete-btn {
+  width: auto;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  background: transparent;
+  color: var(--fail);
+  border: 1px solid rgba(255, 115, 115, 0.4);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.delete-btn:hover {
+  background: rgba(255, 115, 115, 0.1);
+}
+
 .url-line {
   margin: 0.45rem 0;
   font-size: 0.9rem;

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -136,6 +136,25 @@ export function DownloaderDashboard() {
     }
   }
 
+  async function handleDelete(id: string) {
+    if (!confirm("Are you sure you want to delete this download and its files? This cannot be undone.")) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/downloads/${id}`, { method: "DELETE" });
+      if (response.ok) {
+        setFeedback("Item deleted.");
+        setHistory((previous) => previous.filter((record) => record.id !== id));
+        void loadHistory();
+      } else {
+        setFeedback("Failed to delete item.");
+      }
+    } catch {
+      setFeedback("Error deleting item.");
+    }
+  }
+
   return (
     <main className="page-shell">
       <section className="hero-card">
@@ -239,6 +258,14 @@ export function DownloaderDashboard() {
                     title="Retry this download"
                   >
                     Retry
+                  </button>
+                  <button
+                    type="button"
+                    className="delete-btn"
+                    onClick={() => handleDelete(record.id)}
+                    title="Delete this download"
+                  >
+                    Delete
                   </button>
                 </header>
                 <p className="url-line">{record.url}</p>

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -2,20 +2,20 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
-import { getStorageUsage } from "../lib/archive-store";
+import { getStorageUsage, deleteRecord, appendHistory, readHistory, DownloadRecord } from "../lib/archive-store";
 import { DataPaths } from "../lib/ytdlp";
 
+const testRoot = path.join(process.cwd(), "test-data-storage");
+const downloadsDir = path.join(testRoot, "downloads");
+
+const mockPaths: DataPaths = {
+  root: testRoot,
+  downloadsDir: downloadsDir,
+  archiveFile: path.join(testRoot, "archive.txt"),
+  historyFile: path.join(testRoot, "history.json"),
+};
+
 describe("getStorageUsage", () => {
-  const testRoot = path.join(process.cwd(), "test-data-storage");
-  const downloadsDir = path.join(testRoot, "downloads");
-
-  const mockPaths: DataPaths = {
-    root: testRoot,
-    downloadsDir: downloadsDir,
-    archiveFile: path.join(testRoot, "archive.txt"),
-    historyFile: path.join(testRoot, "history.json"),
-  };
-
   beforeEach(async () => {
     await fs.mkdir(downloadsDir, { recursive: true });
   });
@@ -44,5 +44,106 @@ describe("getStorageUsage", () => {
 
     const size = await getStorageUsage(mockPaths);
     expect(size).toBe(3);
+  });
+});
+
+describe("deleteRecord", () => {
+  beforeEach(async () => {
+    await fs.mkdir(downloadsDir, { recursive: true });
+    // Initialize history file
+    await fs.writeFile(mockPaths.historyFile, "[]\n", "utf8");
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRoot, { recursive: true, force: true });
+  });
+
+  it("should return false if record does not exist", async () => {
+    const result = await deleteRecord(mockPaths, "non-existent-id");
+    expect(result).toBe(false);
+  });
+
+  it("should delete record and associated files", async () => {
+    const file1 = "video.mp4";
+    const file2 = "sub/video.mp4"; // nested
+
+    // Create files
+    await fs.writeFile(path.join(downloadsDir, file1), "content");
+    await fs.mkdir(path.join(downloadsDir, "sub"), { recursive: true });
+    await fs.writeFile(path.join(downloadsDir, file2), "content");
+
+    const record: DownloadRecord = {
+      id: "test-id",
+      createdAt: new Date().toISOString(),
+      url: "http://example.com",
+      mode: "video",
+      includePlaylist: false,
+      status: "completed",
+      files: [file1, file2],
+      logTail: "",
+    };
+
+    await appendHistory(mockPaths, record);
+
+    const result = await deleteRecord(mockPaths, "test-id");
+    expect(result).toBe(true);
+
+    // Check history
+    const history = await readHistory(mockPaths);
+    expect(history).toHaveLength(0);
+
+    // Check files
+    await expect(fs.access(path.join(downloadsDir, file1))).rejects.toThrow();
+    await expect(fs.access(path.join(downloadsDir, file2))).rejects.toThrow();
+  });
+
+  it("should ignore missing files and still delete record", async () => {
+    const file1 = "missing.mp4";
+
+    const record: DownloadRecord = {
+      id: "test-id-2",
+      createdAt: new Date().toISOString(),
+      url: "http://example.com",
+      mode: "video",
+      includePlaylist: false,
+      status: "completed",
+      files: [file1],
+      logTail: "",
+    };
+
+    await appendHistory(mockPaths, record);
+
+    const result = await deleteRecord(mockPaths, "test-id-2");
+    expect(result).toBe(true);
+
+    const history = await readHistory(mockPaths);
+    expect(history).toHaveLength(0);
+  });
+
+  it("should not delete files outside of downloads directory (traversal attack)", async () => {
+    const outsideFile = "../secret.txt";
+    const absoluteOutsideFile = path.resolve(downloadsDir, outsideFile);
+
+    // Create a file outside downloadsDir (in testRoot)
+    await fs.writeFile(absoluteOutsideFile, "secret", "utf8");
+
+    const record: DownloadRecord = {
+      id: "malicious-id",
+      createdAt: new Date().toISOString(),
+      url: "http://example.com",
+      mode: "video",
+      includePlaylist: false,
+      status: "completed",
+      files: [outsideFile],
+      logTail: "",
+    };
+
+    await appendHistory(mockPaths, record);
+
+    const result = await deleteRecord(mockPaths, "malicious-id");
+    expect(result).toBe(true); // Record should still be deleted
+
+    // File should still exist
+    await expect(fs.access(absoluteOutsideFile)).resolves.toBeUndefined();
   });
 });

--- a/website/tests/delete_item.spec.ts
+++ b/website/tests/delete_item.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+
+test("should delete a history item", async ({ page }) => {
+  const mockRecord = {
+    id: "test-id",
+    createdAt: new Date().toISOString(),
+    url: "https://example.com/video",
+    mode: "video",
+    includePlaylist: false,
+    status: "completed",
+    files: ["video.mp4"],
+    logTail: "Done",
+  };
+
+  let getCount = 0;
+  await page.route("/api/downloads", async (route) => {
+    if (route.request().method() === "GET") {
+      getCount++;
+      if (getCount === 1) {
+        await route.fulfill({
+          json: {
+            records: [mockRecord],
+            storageUsage: 1024,
+          },
+        });
+      } else {
+        await route.fulfill({
+          json: {
+            records: [],
+            storageUsage: 0,
+          },
+        });
+      }
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route(`/api/downloads/${mockRecord.id}`, async (route) => {
+    expect(route.request().method()).toBe("DELETE");
+    await route.fulfill({
+      status: 200,
+      json: { success: true },
+    });
+  });
+
+  await page.goto("/");
+
+  // Check if item is present
+  await expect(page.getByText("https://example.com/video")).toBeVisible();
+
+  // Setup dialog handler
+  page.on("dialog", (dialog) => dialog.accept());
+
+  // Click delete
+  await page.locator(".delete-btn").click();
+
+  // Check if item is removed
+  await expect(page.getByText("https://example.com/video")).not.toBeVisible();
+  await expect(page.getByText("No downloads yet.")).toBeVisible();
+});


### PR DESCRIPTION
This PR implements the ability for users to delete download history items and their associated files from the disk. It includes backend logic with path traversal protection, a new API endpoint, frontend UI updates, and comprehensive unit and E2E tests.

---
*PR created automatically by Jules for task [5216947659605930058](https://jules.google.com/task/5216947659605930058) started by @jjgroenendijk*