### PR TITLE
Fix verify_storage_usage test path resolution

### DIFF
--- a/website/tests/verify_storage_usage.spec.ts
+++ b/website/tests/verify_storage_usage.spec.ts
@@ -9,7 +9,9 @@ const createDummyFile = (filePath: string, sizeInBytes: number) => {
 };
 
 test.describe('Disk Usage', () => {
-  const dataDir = path.join(process.cwd(), '.data');
+  const dataDir = process.env.DATA_DIR
+    ? path.resolve(process.env.DATA_DIR)
+    : path.join(process.cwd(), '.data');
   const downloadsDir = path.join(dataDir, 'downloads');
   const dummyFile = path.join(downloadsDir, 'test-file-5mb.bin');
   const fileSize = 5 * 1024 * 1024; // 5 MB


### PR DESCRIPTION
Fixes a bug where `verify_storage_usage.spec.ts` would fail when running with a custom `DATA_DIR` because it wrote to a hardcoded path while the server read from the configured path. The test now respects the `DATA_DIR` environment variable.

---
*PR created automatically by Jules for task [5683853320484478809](https://jules.google.com/task/5683853320484478809) started by @jjgroenendijk*