### PR TITLE
Add Video Resolution Limit Feature

### DIFF
--- a/docs/backlog/closed/resolution-limit.md
+++ b/docs/backlog/closed/resolution-limit.md
@@ -1,0 +1,20 @@
+# Video Resolution Limit
+
+## Description
+Add a feature to allow users to select a maximum resolution for video downloads (e.g., 1080p, 720p).
+
+## Motivation
+- Users may want to save disk space or bandwidth.
+- Some devices may not play back 4K or 8K content smoothly.
+
+## Requirements
+- Add a "Resolution" dropdown to the download form (only visible for "Video" mode).
+- Options: "Best" (default), "4K", "1080p", "720p", "480p".
+- Backend should map these to `yt-dlp` format strings:
+  - Best: (default behavior)
+  - 4K: `bestvideo[height<=2160]+bestaudio/best[height<=2160]`
+  - 1080p: `bestvideo[height<=1080]+bestaudio/best[height<=1080]`
+  - 720p: `bestvideo[height<=720]+bestaudio/best[height<=720]`
+  - 480p: `bestvideo[height<=480]+bestaudio/best[height<=480]`
+- Persist the chosen resolution in the download history.
+- Support "Retry" with the original resolution setting.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -90,6 +91,7 @@ export async function POST(request: Request) {
 
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
+  const resolution = typeof body.resolution === "string" ? body.resolution : undefined;
 
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
@@ -100,6 +102,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +122,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +145,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -10,6 +10,7 @@ interface DownloadRecord {
   createdAt: string;
   url: string;
   mode: DownloadMode;
+  resolution?: string;
   includePlaylist: boolean;
   status: DownloadStatus;
   files: string[];
@@ -42,6 +43,7 @@ function formatTimestamp(value: string): string {
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
+  const [resolution, setResolution] = useState<string>("best");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
@@ -52,6 +54,7 @@ export function DownloaderDashboard() {
     setUrl(record.url);
     setMode(record.mode);
     setIncludePlaylist(record.includePlaylist);
+    setResolution(record.resolution || "best");
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -91,6 +94,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution: mode === "video" ? resolution : undefined,
         }),
       });
 
@@ -194,6 +198,23 @@ export function DownloaderDashboard() {
             <option value="audio">Audio (MP3)</option>
           </select>
 
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Max Resolution</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="4k">4K (2160p)</option>
+                <option value="1080p">1080p</option>
+                <option value="720p">720p</option>
+                <option value="480p">480p</option>
+              </select>
+            </>
+          )}
+
           <label className="checkbox-row" htmlFor="playlist">
             <input
               id="playlist"
@@ -254,6 +275,9 @@ export function DownloaderDashboard() {
                   </span>
                   <span>{formatTimestamp(record.createdAt)}</span>
                   <span>{record.mode}</span>
+                  {record.resolution && record.resolution !== "best" && (
+                    <span className="text-xs bg-gray-200 px-1 rounded">{record.resolution}</span>
+                  )}
                   <button
                     type="button"
                     className="retry-btn"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -8,6 +8,7 @@ export interface DownloadRecord {
   createdAt: string;
   url: string;
   mode: "video" | "audio";
+  resolution?: string;
   includePlaylist: boolean;
   status: "completed" | "failed";
   files: string[];

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -83,7 +84,18 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    let format = "bv*+ba/b";
+
+    if (request.resolution) {
+      const height = request.resolution.replace("p", "");
+      if (request.resolution === "4k") {
+        format = "bestvideo[height<=2160]+bestaudio/best[height<=2160]";
+      } else if (!isNaN(Number(height))) {
+        format = `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`;
+      }
+    }
+
+    args.push("--format", format);
   }
 
   args.push(request.url);

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,54 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with resolution limit", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "1080p",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bestvideo[height<=1080]+bestaudio/best[height<=1080]");
+  });
+
+  it("builds video flags with 4k resolution", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "4k",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bestvideo[height<=2160]+bestaudio/best[height<=2160]");
+  });
+
+  it("ignores invalid resolution and uses default", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "invalid",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bv*+ba/b");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Implemented a new feature to limit video resolution for downloads.
This allows users to save disk space and bandwidth by selecting a maximum resolution (e.g., 1080p, 720p).
The resolution is passed to yt-dlp using format strings and persisted in the history for retries.
Verified with unit tests and frontend screenshot verification.

---
*PR created automatically by Jules for task [8932898685612051289](https://jules.google.com/task/8932898685612051289) started by @jjgroenendijk*