### PR TITLE
feat: Add resolution limit to downloader

### DIFF
--- a/docs/backlog/closed/resolution-limit.md
+++ b/docs/backlog/closed/resolution-limit.md
@@ -1,0 +1,12 @@
+# Resolution Limit
+
+## Description
+Add a "Resolution Limit" dropdown to the downloader dashboard. This allows users to specify a maximum video resolution (e.g., 1080p, 720p) to save storage space and bandwidth.
+
+## Requirements
+- [ ] Frontend: Add a dropdown with options: "Best", "4K", "1440p", "1080p", "720p".
+- [ ] Frontend: Send selected resolution to the backend.
+- [ ] Backend: Receive `resolution` parameter.
+- [ ] Backend: Update `yt-dlp` arguments to respect the resolution limit.
+- [ ] Backend: Store resolution preference in history? (Optional but good for Retry).
+- [ ] Tests: Add unit/E2E tests for the new feature.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -90,6 +91,7 @@ export async function POST(request: Request) {
 
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
+  const resolution = typeof body.resolution === "string" ? body.resolution : undefined;
 
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
@@ -100,6 +102,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +122,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +145,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -11,6 +11,7 @@ interface DownloadRecord {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
   status: DownloadStatus;
   files: string[];
   logTail: string;
@@ -42,6 +43,7 @@ function formatTimestamp(value: string): string {
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
+  const [resolution, setResolution] = useState<string>("best");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
@@ -52,6 +54,7 @@ export function DownloaderDashboard() {
     setUrl(record.url);
     setMode(record.mode);
     setIncludePlaylist(record.includePlaylist);
+    setResolution(record.resolution || "best");
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -91,6 +94,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution,
         }),
       });
 
@@ -110,6 +114,7 @@ export function DownloaderDashboard() {
 
       setFeedback("Download complete.");
       setUrl("");
+      setResolution("best");
       void loadHistory();
     } catch {
       setFeedback("Request failed. Check network or server logs.");
@@ -193,6 +198,23 @@ export function DownloaderDashboard() {
             <option value="video">Best Video + Audio</option>
             <option value="audio">Audio (MP3)</option>
           </select>
+
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Resolution Limit</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
 
           <label className="checkbox-row" htmlFor="playlist">
             <input

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -9,6 +9,7 @@ export interface DownloadRecord {
   url: string;
   mode: "video" | "audio";
   includePlaylist: boolean;
+  resolution?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -83,7 +84,16 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    let format = "bv*+ba/b";
+
+    if (request.resolution && request.resolution !== "best") {
+      const height = parseInt(request.resolution, 10);
+      if (!isNaN(height)) {
+        format = `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`;
+      }
+    }
+
+    args.push("--format", format);
   }
 
   args.push(request.url);

--- a/website/tests/home.spec.ts
+++ b/website/tests/home.spec.ts
@@ -74,5 +74,6 @@ test("submits a download and displays history", async ({ page }) => {
     url: "https://example.com/watch?v=123",
     mode: "audio",
     includePlaylist: true,
+    resolution: "best",
   });
 });

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+test("resolution dropdown visibility and submission", async ({ page }) => {
+  await page.route("/api/downloads", async (route) => {
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          record: {
+            id: "mock-id",
+            createdAt: new Date().toISOString(),
+            url: body.url,
+            mode: body.mode,
+            includePlaylist: body.includePlaylist,
+            resolution: body.resolution,
+            status: "completed",
+            files: [],
+            logTail: "",
+          },
+        }),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ records: [], storageUsage: 0 }),
+      });
+    }
+  });
+
+  await page.goto("/");
+
+  // Check default state (Video mode)
+  await expect(page.getByLabel("Resolution Limit")).toBeVisible();
+
+  // Switch to Audio
+  await page.getByLabel("Mode").selectOption("audio");
+  await expect(page.getByLabel("Resolution Limit")).toBeHidden();
+
+  // Switch back to Video
+  await page.getByLabel("Mode").selectOption("video");
+  await expect(page.getByLabel("Resolution Limit")).toBeVisible();
+
+  // Select 720p
+  await page.getByLabel("Resolution Limit").selectOption("720p");
+  await page.getByLabel("Video URL").fill("https://example.com/video");
+
+  // Verify request
+  const requestPromise = page.waitForRequest((request) =>
+    request.url().includes("/api/downloads") && request.method() === "POST"
+  );
+
+  await page.getByRole("button", { name: "Download and Archive" }).click();
+
+  const request = await requestPromise;
+  const body = request.postDataJSON();
+
+  expect(body.resolution).toBe("720p");
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,38 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with resolution limit", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "1080p",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bestvideo[height<=1080]+bestaudio/best[height<=1080]");
+  });
+
+  it("builds video flags with best resolution", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "best",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bv*+ba/b");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Added a resolution limit dropdown to the downloader dashboard, allowing users to select a maximum resolution (e.g., 1080p, 720p). Updated the backend to handle the resolution parameter and modify yt-dlp arguments accordingly. Added unit and E2E tests.

---
*PR created automatically by Jules for task [7203066052288452806](https://jules.google.com/task/7203066052288452806) started by @jjgroenendijk*