### PR TITLE
Add resolution limit option for video downloads

### DIFF
--- a/docs/backlog/closed/006_resolution_limit.md
+++ b/docs/backlog/closed/006_resolution_limit.md
@@ -1,0 +1,18 @@
+# Resolution Limit for Video Downloads
+
+## Status
+Closed
+
+## Description
+Add a resolution limit option to the `yt-dlp` web interface. Users should be able to select a maximum resolution (e.g., 1080p, 720p) when downloading videos. This helps in managing disk usage and bandwidth.
+
+## Requirements
+- [x] Update `DownloadRequest` interface to include optional `resolution` field.
+- [x] Update `buildYtDlpArgs` to handle resolution limits.
+- [x] Update frontend UI to include a resolution dropdown (visible only for video mode).
+- [x] Ensure resolution is passed to the API and stored in history.
+- [x] Add tests for the new functionality.
+
+## Implementation Details
+- Used `bestvideo[height<=HEIGHT]+bestaudio/best[height<=HEIGHT]` format string for `yt-dlp`.
+- Supported resolutions: Best, 4K (2160p), QHD (1440p), FHD (1080p), HD (720p).

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -90,6 +91,7 @@ export async function POST(request: Request) {
 
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
+  const resolution = typeof body.resolution === "string" ? body.resolution : undefined;
 
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
@@ -100,6 +102,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +122,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +145,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -11,6 +11,7 @@ interface DownloadRecord {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
   status: DownloadStatus;
   files: string[];
   logTail: string;
@@ -42,6 +43,7 @@ function formatTimestamp(value: string): string {
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
+  const [resolution, setResolution] = useState("best");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
@@ -51,6 +53,7 @@ export function DownloaderDashboard() {
   function handleRetry(record: DownloadRecord) {
     setUrl(record.url);
     setMode(record.mode);
+    setResolution(record.resolution ?? "best");
     setIncludePlaylist(record.includePlaylist);
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
@@ -91,6 +94,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution,
         }),
       });
 
@@ -193,6 +197,23 @@ export function DownloaderDashboard() {
             <option value="video">Best Video + Audio</option>
             <option value="audio">Audio (MP3)</option>
           </select>
+
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Resolution Limit</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
 
           <label className="checkbox-row" htmlFor="playlist">
             <input

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -9,6 +9,7 @@ export interface DownloadRecord {
   url: string;
   mode: "video" | "audio";
   includePlaylist: boolean;
+  resolution?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -83,7 +84,14 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    const res = request.resolution;
+    if (res && res !== "best") {
+      // Map "1080p" -> 1080
+      const height = res.replace("p", "");
+      args.push("--format", `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`);
+    } else {
+      args.push("--format", "bv*+ba/b");
+    }
   }
 
   args.push(request.url);

--- a/website/tests/home.spec.ts
+++ b/website/tests/home.spec.ts
@@ -74,5 +74,6 @@ test("submits a download and displays history", async ({ page }) => {
     url: "https://example.com/watch?v=123",
     mode: "audio",
     includePlaylist: true,
+    resolution: "best",
   });
 });

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+
+test("selects resolution and submits download request", async ({ page }) => {
+  let requestBody: Record<string, unknown> | null = null;
+  const postedRecord = {
+    id: "run-res-1",
+    createdAt: "2026-02-08T10:00:00.000Z",
+    url: "https://example.com/watch?v=res123",
+    mode: "video",
+    includePlaylist: false,
+    resolution: "1080p",
+    status: "completed",
+    files: ["creator/2026-02-08/video-1080p.mp4"],
+    logTail: "done",
+  };
+
+  await page.route("**/api/downloads", async (route) => {
+    const method = route.request().method();
+
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ records: requestBody ? [postedRecord] : [] }),
+      });
+      return;
+    }
+
+    if (method === "POST") {
+      requestBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          record: postedRecord,
+        }),
+      });
+      return;
+    }
+
+    await route.fallback();
+  });
+
+  await page.goto("/");
+  await page.getByLabel("Video URL").fill("https://example.com/watch?v=res123");
+  await page.getByLabel("Mode").selectOption("video"); // Ensure video mode is selected to see resolution
+  await page.getByLabel("Resolution Limit").selectOption("1080p");
+  await page.getByRole("button", { name: "Download and Archive" }).click();
+
+  await expect(page.getByTestId("status-text")).toHaveText("Download complete.");
+  await expect(page.getByTestId("history-list")).toContainText("creator/2026-02-08/video-1080p.mp4");
+
+  expect(requestBody).toEqual({
+    url: "https://example.com/watch?v=res123",
+    mode: "video",
+    includePlaylist: false,
+    resolution: "1080p",
+  });
+});
+
+test("hides resolution dropdown when audio mode is selected", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByLabel("Resolution Limit")).toBeVisible();
+
+  await page.getByLabel("Mode").selectOption("audio");
+  await expect(page.getByLabel("Resolution Limit")).toBeHidden();
+
+  await page.getByLabel("Mode").selectOption("video");
+  await expect(page.getByLabel("Resolution Limit")).toBeVisible();
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,42 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with resolution limit", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "1080p",
+      },
+      paths,
+    );
+
+    const formatIndex = args.indexOf("--format");
+    expect(formatIndex).toBeGreaterThan(-1);
+    expect(args[formatIndex + 1]).toBe(
+      "bestvideo[height<=1080]+bestaudio/best[height<=1080]",
+    );
+  });
+
+  it("builds video flags with default resolution (best)", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "best",
+      },
+      paths,
+    );
+
+    const formatIndex = args.indexOf("--format");
+    expect(formatIndex).toBeGreaterThan(-1);
+    expect(args[formatIndex + 1]).toBe("bv*+ba/b");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Implemented a resolution limit feature for video downloads. Users can now select a maximum resolution (e.g., 1080p) from the dashboard. This is useful for managing storage space and download bandwidth.

Changes:
- Frontend: Added a resolution dropdown that appears when "video" mode is selected.
- Backend: Updated `DownloadRequest` and `DownloadRecord` interfaces to support `resolution`.
- Logic: Modified `buildYtDlpArgs` to generate the correct `yt-dlp` format string based on the selected resolution.
- Tests: Added unit tests for argument generation and an E2E test for the full user flow.
- Documentation: Added closed backlog item.

---
*PR created automatically by Jules for task [11453372213882232522](https://jules.google.com/task/11453372213882232522) started by @jjgroenendijk*