### PR TITLE
Add resolution selection to downloader

### DIFF
--- a/docs/backlog/closed/resolution-selection.md
+++ b/docs/backlog/closed/resolution-selection.md
@@ -1,0 +1,11 @@
+# Add Resolution Selection to Downloader
+
+## Description
+The current downloader defaults to "best video + audio". Users should be able to select a maximum resolution (e.g., 1080p, 720p) to save space or bandwidth.
+
+## Requirements
+- [x] Add a resolution dropdown to the UI (Best, 4K, 1440p, 1080p, 720p).
+- [x] Pass the resolution parameter to the backend.
+- [x] Update `yt-dlp` arguments to respect the resolution limit (e.g. `bestvideo[height<=1080]+bestaudio/best[height<=1080]`).
+- [x] Store the selected resolution in the download history.
+- [x] Update tests.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -90,6 +91,7 @@ export async function POST(request: Request) {
 
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
+  const resolution = typeof body.resolution === "string" ? body.resolution : undefined;
 
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
@@ -100,6 +102,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +122,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +145,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -11,6 +11,7 @@ interface DownloadRecord {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
   status: DownloadStatus;
   files: string[];
   logTail: string;
@@ -42,6 +43,7 @@ function formatTimestamp(value: string): string {
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
+  const [resolution, setResolution] = useState("best");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
@@ -52,6 +54,7 @@ export function DownloaderDashboard() {
     setUrl(record.url);
     setMode(record.mode);
     setIncludePlaylist(record.includePlaylist);
+    setResolution(record.resolution ?? "best");
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -91,6 +94,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution,
         }),
       });
 
@@ -190,9 +194,26 @@ export function DownloaderDashboard() {
             value={mode}
             onChange={(event) => setMode(event.target.value as DownloadMode)}
           >
-            <option value="video">Best Video + Audio</option>
+            <option value="video">Video</option>
             <option value="audio">Audio (MP3)</option>
           </select>
+
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Resolution Limit</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
 
           <label className="checkbox-row" htmlFor="playlist">
             <input
@@ -253,7 +274,12 @@ export function DownloaderDashboard() {
                     {record.status}
                   </span>
                   <span>{formatTimestamp(record.createdAt)}</span>
-                  <span>{record.mode}</span>
+                  <span>
+                    {record.mode}
+                    {record.mode === "video" && record.resolution && record.resolution !== "best"
+                      ? ` (${record.resolution})`
+                      : ""}
+                  </span>
                   <button
                     type="button"
                     className="retry-btn"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -9,6 +9,7 @@ export interface DownloadRecord {
   url: string;
   mode: "video" | "audio";
   includePlaylist: boolean;
+  resolution?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -82,6 +83,13 @@ export function buildYtDlpArgs(
 
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
+  } else if (request.resolution && request.resolution !== "best") {
+    // e.g. "1080p" -> "1080"
+    const height = request.resolution.replace("p", "");
+    args.push(
+      "--format",
+      `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`,
+    );
   } else {
     args.push("--format", "bv*+ba/b");
   }

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+test("selects resolution and submits download", async ({ page }) => {
+  // Mock the API to capture the request
+  let capturedRequest: any = null;
+  await page.route("/api/downloads", async (route) => {
+    if (route.request().method() === "POST") {
+      capturedRequest = await route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          record: {
+            id: "test-id",
+            createdAt: new Date().toISOString(),
+            url: "https://example.com/watch?v=resolution",
+            mode: "video",
+            resolution: "1080p",
+            includePlaylist: false,
+            status: "completed",
+            files: [],
+            logTail: "Test log",
+          },
+        }),
+      });
+    } else if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          records: [
+            {
+              id: "test-id",
+              createdAt: new Date().toISOString(),
+              url: "https://example.com/watch?v=resolution",
+              mode: "video",
+              resolution: "1080p",
+              includePlaylist: false,
+              status: "completed",
+              files: [],
+              logTail: "Test log",
+            },
+          ],
+          storageUsage: 1024,
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/");
+
+  // Fill in the form
+  await page.getByLabel("Video URL").fill("https://example.com/watch?v=resolution");
+
+  // Select Video mode (should be default)
+  await expect(page.getByLabel("Mode")).toHaveValue("video");
+
+  // Select Resolution
+  await page.getByLabel("Resolution Limit").selectOption("1080p");
+
+  // Submit
+  await page.getByRole("button", { name: "Download and Archive" }).click();
+
+  // Verify the request
+  expect(capturedRequest).toBeTruthy();
+  expect(capturedRequest.url).toBe("https://example.com/watch?v=resolution");
+  expect(capturedRequest.mode).toBe("video");
+  expect(capturedRequest.resolution).toBe("1080p");
+
+  // Verify the history item displays the resolution
+  await expect(page.getByTestId("history-list")).toContainText("video (1080p)");
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,24 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with resolution limit", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "1080p",
+      },
+      paths,
+    );
+
+    expect(args).toContain(
+      "bestvideo[height<=1080]+bestaudio/best[height<=1080]",
+    );
+    expect(args).toContain("--no-playlist");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Implemented resolution selection for video downloads. Users can now choose between 'Best Available', '4K', 'QHD', 'FHD', and 'HD'. This preference is passed to `yt-dlp` to limit the video height and is stored in the download history.

- Added resolution dropdown to UI.
- Updated `yt-dlp` arguments construction.
- Updated API and storage logic.
- Added tests.

---
*PR created automatically by Jules for task [11897995656457349128](https://jules.google.com/task/11897995656457349128) started by @jjgroenendijk*