### PR TITLE
Add Resolution Limit Feature

### DIFF
--- a/docs/backlog/closed/resolution_limit.md
+++ b/docs/backlog/closed/resolution_limit.md
@@ -1,0 +1,17 @@
+# Resolution Limit
+
+## Description
+Add a feature to allow users to select a maximum resolution for video downloads. Currently, downloads default to "Best Video + Audio". This can result in very large files (e.g., 4K/8K) that consume excessive disk space.
+
+## Requirements
+- Add a dropdown to the `DownloaderDashboard` component.
+- Options: "Best Available" (default), "4K (2160p)", "QHD (1440p)", "FHD (1080p)", "HD (720p)".
+- Pass the selected resolution to the backend API.
+- Update `yt-dlp` arguments construction to respect the resolution limit.
+- Persist the chosen resolution in the download history.
+
+## Acceptance Criteria
+- User can select a resolution from the dropdown.
+- The selected resolution is sent to the backend.
+- `yt-dlp` runs with the appropriate format selection (e.g., `bestvideo[height<=1080]+bestaudio/best[height<=1080]`).
+- Download history shows the selected resolution.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -71,6 +71,7 @@ export async function POST(request: Request) {
   const body = (await request.json()) as {
     url?: string;
     mode?: unknown;
+    resolution?: unknown;
     includePlaylist?: unknown;
   };
 
@@ -89,6 +90,7 @@ export async function POST(request: Request) {
   }
 
   const mode = parseMode(body.mode);
+  const resolution = typeof body.resolution === "string" ? body.resolution : undefined;
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
 
   const dataDir = resolveDataDir();
@@ -99,6 +101,7 @@ export async function POST(request: Request) {
     {
       url: validatedUrl,
       mode,
+      resolution,
       includePlaylist,
     },
     paths,
@@ -118,6 +121,7 @@ export async function POST(request: Request) {
       createdAt: startedAt,
       url: validatedUrl,
       mode,
+      resolution,
       includePlaylist,
       status: code === 0 ? "completed" : "failed",
       files,
@@ -140,6 +144,7 @@ export async function POST(request: Request) {
       createdAt: startedAt,
       url: validatedUrl,
       mode,
+      resolution,
       includePlaylist,
       status: "failed",
       files: [],

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -10,6 +10,7 @@ interface DownloadRecord {
   createdAt: string;
   url: string;
   mode: DownloadMode;
+  resolution?: string;
   includePlaylist: boolean;
   status: DownloadStatus;
   files: string[];
@@ -42,6 +43,7 @@ function formatTimestamp(value: string): string {
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
+  const [resolution, setResolution] = useState("best");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
@@ -51,6 +53,7 @@ export function DownloaderDashboard() {
   function handleRetry(record: DownloadRecord) {
     setUrl(record.url);
     setMode(record.mode);
+    setResolution(record.resolution || "best");
     setIncludePlaylist(record.includePlaylist);
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
@@ -90,6 +93,7 @@ export function DownloaderDashboard() {
         body: JSON.stringify({
           url,
           mode,
+          resolution,
           includePlaylist,
         }),
       });
@@ -194,6 +198,23 @@ export function DownloaderDashboard() {
             <option value="audio">Audio (MP3)</option>
           </select>
 
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Resolution Limit</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
+
           <label className="checkbox-row" htmlFor="playlist">
             <input
               id="playlist"
@@ -254,6 +275,7 @@ export function DownloaderDashboard() {
                   </span>
                   <span>{formatTimestamp(record.createdAt)}</span>
                   <span>{record.mode}</span>
+                  {record.resolution && <span>{record.resolution}</span>}
                   <button
                     type="button"
                     className="retry-btn"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -8,6 +8,7 @@ export interface DownloadRecord {
   createdAt: string;
   url: string;
   mode: "video" | "audio";
+  resolution?: string;
   includePlaylist: boolean;
   status: "completed" | "failed";
   files: string[];

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -5,6 +5,7 @@ export type DownloadMode = "video" | "audio";
 export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
+  resolution?: string;
   includePlaylist: boolean;
 }
 
@@ -83,7 +84,19 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    if (request.resolution && request.resolution !== "best") {
+      const height = parseInt(request.resolution.replace("p", ""), 10);
+      if (!isNaN(height)) {
+        args.push(
+          "--format",
+          `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`,
+        );
+      } else {
+        args.push("--format", "bv*+ba/b");
+      }
+    } else {
+      args.push("--format", "bv*+ba/b");
+    }
   }
 
   args.push(request.url);

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+test("sends resolution limit in download request", async ({ page }) => {
+  await page.route("/api/downloads", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        json: { records: [], storageUsage: 0 },
+      });
+    } else if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON();
+      expect(body).toMatchObject({
+        url: "https://www.youtube.com/watch?v=123",
+        mode: "video",
+        resolution: "1080p",
+        includePlaylist: false,
+      });
+
+      await route.fulfill({
+        json: {
+          record: {
+            id: "test-id",
+            createdAt: new Date().toISOString(),
+            url: "https://www.youtube.com/watch?v=123",
+            mode: "video",
+            resolution: "1080p",
+            includePlaylist: false,
+            status: "completed",
+            files: [],
+            logTail: "done",
+          },
+        },
+      });
+    }
+  });
+
+  await page.goto("/");
+  await page.fill("#video-url", "https://www.youtube.com/watch?v=123");
+
+  // Select 1080p
+  await page.selectOption("#resolution", "1080p");
+
+  await page.click("button[type='submit']");
+
+  await expect(page.getByText("Download complete.")).toBeVisible();
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,38 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with resolution limit", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        resolution: "1080p",
+        includePlaylist: false,
+      },
+      paths,
+    );
+
+    expect(args).toContain(
+      "bestvideo[height<=1080]+bestaudio/best[height<=1080]",
+    );
+  });
+
+  it("builds video flags with best resolution (default)", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        resolution: "best",
+        includePlaylist: false,
+      },
+      paths,
+    );
+
+    expect(args).toContain("bv*+ba/b");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Implemented a resolution limit feature for video downloads.

- Added `resolution` field to `DownloadRecord` and `DownloadRequest`.
- Updated `DownloaderDashboard` to include a resolution dropdown (Best, 4K, QHD, FHD, HD) when mode is "video".
- Updated `POST /api/downloads` to handle the resolution parameter.
- Updated `buildYtDlpArgs` to use `bestvideo[height<=H]+bestaudio/best[height<=H]` format selection.
- Added unit tests for argument construction.
- Added E2E test for UI interaction.
- Moved backlog item to closed.

---
*PR created automatically by Jules for task [18063457353620803102](https://jules.google.com/task/18063457353620803102) started by @jjgroenendijk*