### PR TITLE
Add resolution limit feature

### DIFF
--- a/docs/backlog/closed/resolution-limit.md
+++ b/docs/backlog/closed/resolution-limit.md
@@ -1,0 +1,13 @@
+# Resolution Limit
+
+## Description
+Allow users to select a maximum video resolution (e.g., 720p, 1080p, 4K) when downloading videos.
+
+## Rationale
+"Best Video + Audio" often downloads 4K or 8K files which are huge. A common user requirement for `yt-dlp` wrappers is resolution control to save disk space and bandwidth.
+
+## Requirements
+- Add a resolution dropdown to the UI (Video mode only).
+- Pass the resolution to the backend.
+- Use `yt-dlp` arguments to limit resolution (e.g., `bestvideo[height<=720]+bestaudio/best[height<=720]`).
+- Store the resolution in the download history.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -90,6 +91,8 @@ export async function POST(request: Request) {
 
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
+  const resolution =
+    typeof body.resolution === "string" ? body.resolution : undefined;
 
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
@@ -100,6 +103,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +123,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +146,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -10,6 +10,7 @@ interface DownloadRecord {
   createdAt: string;
   url: string;
   mode: DownloadMode;
+  resolution?: string;
   includePlaylist: boolean;
   status: DownloadStatus;
   files: string[];
@@ -42,6 +43,7 @@ function formatTimestamp(value: string): string {
 export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
+  const [resolution, setResolution] = useState<string>("best");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
@@ -51,6 +53,7 @@ export function DownloaderDashboard() {
   function handleRetry(record: DownloadRecord) {
     setUrl(record.url);
     setMode(record.mode);
+    setResolution(record.resolution ?? "best");
     setIncludePlaylist(record.includePlaylist);
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
@@ -91,6 +94,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution,
         }),
       });
 
@@ -194,6 +198,23 @@ export function DownloaderDashboard() {
             <option value="audio">Audio (MP3)</option>
           </select>
 
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Resolution Limit</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
+
           <label className="checkbox-row" htmlFor="playlist">
             <input
               id="playlist"
@@ -254,6 +275,9 @@ export function DownloaderDashboard() {
                   </span>
                   <span>{formatTimestamp(record.createdAt)}</span>
                   <span>{record.mode}</span>
+                  {record.mode === "video" && record.resolution && (
+                    <span>{record.resolution}</span>
+                  )}
                   <button
                     type="button"
                     className="retry-btn"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -8,6 +8,7 @@ export interface DownloadRecord {
   createdAt: string;
   url: string;
   mode: "video" | "audio";
+  resolution?: string;
   includePlaylist: boolean;
   status: "completed" | "failed";
   files: string[];

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -83,7 +84,15 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    if (request.resolution && request.resolution !== "best") {
+      const height = request.resolution.replace("p", "");
+      args.push(
+        "--format",
+        `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`,
+      );
+    } else {
+      args.push("--format", "bv*+ba/b");
+    }
   }
 
   args.push(request.url);

--- a/website/tests/home.spec.ts
+++ b/website/tests/home.spec.ts
@@ -74,5 +74,6 @@ test("submits a download and displays history", async ({ page }) => {
     url: "https://example.com/watch?v=123",
     mode: "audio",
     includePlaylist: true,
+    resolution: "best",
   });
 });

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+test("selects resolution and submits download request", async ({ page }) => {
+  let requestBody: Record<string, unknown> | null = null;
+  const postedRecord = {
+    id: "run-res-1",
+    createdAt: "2026-02-08T12:00:00.000Z",
+    url: "https://example.com/watch?v=res",
+    mode: "video",
+    resolution: "1080p",
+    includePlaylist: false,
+    status: "completed",
+    files: [],
+    logTail: "done",
+  };
+
+  await page.route("**/api/downloads", async (route) => {
+    const method = route.request().method();
+
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ records: requestBody ? [postedRecord] : [] }),
+      });
+      return;
+    }
+
+    requestBody = JSON.parse(route.request().postData() ?? "{}");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        record: postedRecord,
+      }),
+    });
+  });
+
+  await page.goto("/");
+
+  // Check default resolution
+  await expect(page.getByLabel("Resolution Limit")).toHaveValue("best");
+
+  // Fill form
+  await page.getByLabel("Video URL").fill("https://example.com/watch?v=res");
+  await page.getByLabel("Resolution Limit").selectOption("1080p");
+  await page.getByRole("button", { name: "Download and Archive" }).click();
+
+  await expect(page.getByTestId("status-text")).toHaveText("Download complete.");
+
+  // Check request body
+  expect(requestBody).toEqual({
+    url: "https://example.com/watch?v=res",
+    mode: "video",
+    resolution: "1080p",
+    includePlaylist: false,
+  });
+
+  // Check history display
+  await expect(page.getByTestId("history-list")).toContainText("1080p");
+});
+
+test("hides resolution dropdown in audio mode", async ({ page }) => {
+  await page.route("**/api/downloads", async (route) => {
+    if (route.request().method() === "GET") {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ records: [] }),
+        });
+    }
+  });
+
+  await page.goto("/");
+  await expect(page.getByLabel("Resolution Limit")).toBeVisible();
+
+  await page.getByLabel("Mode").selectOption("audio");
+  await expect(page.getByLabel("Resolution Limit")).toBeHidden();
+
+  await page.getByLabel("Mode").selectOption("video");
+  await expect(page.getByLabel("Resolution Limit")).toBeVisible();
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,39 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with resolution limit", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=res",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "720p",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain(
+      "bestvideo[height<=720]+bestaudio/best[height<=720]",
+    );
+  });
+
+  it("defaults to best video if resolution is best", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=res",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "best",
+      },
+      paths,
+    );
+
+    expect(args).toContain("bv*+ba/b");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Adds a resolution dropdown to the UI (video mode only), updates the API to handle the resolution parameter, and updates yt-dlp argument construction to respect the limit.

---
*PR created automatically by Jules for task [824160382499443216](https://jules.google.com/task/824160382499443216) started by @jjgroenendijk*