### PR TITLE
Harden automation for public repo visibility

### DIFF
--- a/.github/workflows/manage-pr-lifecycle.yml
+++ b/.github/workflows/manage-pr-lifecycle.yml
@@ -21,11 +21,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Merge Passed PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          TRUSTED_ACTORS: ${{ vars.JULES_TRUSTED_ACTORS }}
         run: |
           set -euo pipefail
           echo '${{ toJSON(github.event.workflow_run) }}' > workflow_run.json
@@ -52,12 +56,25 @@ jobs:
           for PR_NUMBER in $PR_NUMBERS; do
             echo "Processing PR #$PR_NUMBER"
 
-            PR_STATE=$(gh pr view "$PR_NUMBER" \
+            PR_DATA=$(gh pr view "$PR_NUMBER" \
               --repo "${{ github.repository }}" \
-              --json state \
-              -q '.state')
+              --json state,author,isCrossRepository,headRepositoryOwner)
+            PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
             if [ "$PR_STATE" != "OPEN" ]; then
               echo "PR #$PR_NUMBER is $PR_STATE. Skipping."
+              continue
+            fi
+
+            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // empty')
+            PR_IS_CROSS=$(echo "$PR_DATA" | jq -r '.isCrossRepository')
+            PR_HEAD_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login // empty')
+            if ! python3 automation_trust.py pr \
+              --author "$PR_AUTHOR" \
+              --head-owner "$PR_HEAD_OWNER" \
+              --is-cross "$PR_IS_CROSS" \
+              --repo-owner "${{ github.repository_owner }}" \
+              --trusted-actors "$TRUSTED_ACTORS"; then
+              echo "PR #$PR_NUMBER is not a trusted same-repo PR. Skipping auto-merge."
               continue
             fi
 

--- a/.github/workflows/report-ci-failure.yml
+++ b/.github/workflows/report-ci-failure.yml
@@ -15,20 +15,23 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     permissions:
       issues: write
-      contents: read
       actions: write
       pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Report Failure
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          TRUSTED_ACTORS: ${{ vars.JULES_TRUSTED_ACTORS }}
         run: |
+          set -euo pipefail
+
           # Save payload to file
           echo '${{ toJSON(github.event.workflow_run) }}' > workflow_run.json
 
@@ -55,6 +58,28 @@ jobs:
           python3 .github/scripts/extract_log.py failed.log > snippet.txt
 
           for PR_NUMBER in $PR_NUMBERS; do
+            PR_DATA=$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json author,isCrossRepository,headRepositoryOwner,state)
+            PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
+            if [ "$PR_STATE" != "OPEN" ]; then
+              echo "PR #$PR_NUMBER is $PR_STATE. Skipping."
+              continue
+            fi
+
+            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login // empty')
+            PR_IS_CROSS=$(echo "$PR_DATA" | jq -r '.isCrossRepository')
+            PR_HEAD_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login // empty')
+            if ! python3 automation_trust.py pr \
+              --author "$PR_AUTHOR" \
+              --head-owner "$PR_HEAD_OWNER" \
+              --is-cross "$PR_IS_CROSS" \
+              --repo-owner "${{ github.repository_owner }}" \
+              --trusted-actors "$TRUSTED_ACTORS"; then
+              echo "PR #$PR_NUMBER is not a trusted same-repo PR. Skipping."
+              continue
+            fi
+
             echo "Creating issue for PR #$PR_NUMBER"
             TITLE="CI Failure: PR #$PR_NUMBER"
 

--- a/.github/workflows/run-agent.yml
+++ b/.github/workflows/run-agent.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/verify-codebase.yml
+++ b/.github/workflows/verify-codebase.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -44,6 +49,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is configured for **Google Jules** autonomous development and in
 ## Jules workflow
 
 Open a new GitHub issue with the task you want Jules to perform.
-Only issues opened by the repository owner automatically start or queue a Jules session.
+By default, only issues opened by the repository owner automatically start or queue a Jules session.
 
 The automation will:
 
@@ -26,6 +26,10 @@ Required secrets:
 
 - `GOOGLE_JULES_API`
 - `GITHUB_TOKEN` (provided by GitHub Actions)
+
+Optional repository variable:
+
+- `JULES_TRUSTED_ACTORS`: JSON array of extra trusted logins for privileged PR follow-up automation, such as `["app/google-jules"]`
 
 ## Local development
 

--- a/automation_trust.py
+++ b/automation_trust.py
@@ -1,0 +1,102 @@
+import argparse
+import json
+
+
+def parse_trusted_actors(raw_value, repo_owner):
+    """Return the normalized trusted-actor set, always including the repo owner."""
+    trusted = set()
+    if repo_owner:
+        trusted.add(repo_owner.strip().lower())
+
+    if not raw_value:
+        return trusted
+
+    raw_value = raw_value.strip()
+    if not raw_value:
+        return trusted
+
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if isinstance(parsed, list):
+        for actor in parsed:
+            if isinstance(actor, str) and actor.strip():
+                trusted.add(actor.strip().lower())
+        return trusted
+
+    for actor in raw_value.split(","):
+        actor = actor.strip()
+        if actor:
+            trusted.add(actor.lower())
+
+    return trusted
+
+
+def is_trusted_actor(actor_login, repo_owner, trusted_actors_raw=None):
+    """Return True when the actor is trusted for privileged automation."""
+    if not actor_login:
+        return False
+    return actor_login.strip().lower() in parse_trusted_actors(trusted_actors_raw, repo_owner)
+
+
+def _as_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return bool(value)
+
+
+def is_trusted_pr(
+    author_login,
+    head_owner_login,
+    is_cross_repository,
+    repo_owner,
+    trusted_actors_raw=None,
+):
+    """Return True for same-repo PRs from trusted authors only."""
+    if _as_bool(is_cross_repository):
+        return False
+    if not repo_owner or not head_owner_login:
+        return False
+    if head_owner_login.strip().lower() != repo_owner.strip().lower():
+        return False
+    return is_trusted_actor(author_login, repo_owner, trusted_actors_raw)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate trusted automation actors and PRs.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    actor_parser = subparsers.add_parser("actor", help="Check whether an actor is trusted.")
+    actor_parser.add_argument("--actor", required=True)
+    actor_parser.add_argument("--repo-owner", required=True)
+    actor_parser.add_argument("--trusted-actors", default="")
+
+    pr_parser = subparsers.add_parser("pr", help="Check whether a PR is trusted.")
+    pr_parser.add_argument("--author", required=True)
+    pr_parser.add_argument("--head-owner", required=True)
+    pr_parser.add_argument("--is-cross", required=True)
+    pr_parser.add_argument("--repo-owner", required=True)
+    pr_parser.add_argument("--trusted-actors", default="")
+
+    args = parser.parse_args()
+
+    if args.command == "actor":
+        trusted = is_trusted_actor(args.actor, args.repo_owner, args.trusted_actors)
+        raise SystemExit(0 if trusted else 1)
+
+    trusted = is_trusted_pr(
+        args.author,
+        args.head_owner,
+        args.is_cross,
+        args.repo_owner,
+        args.trusted_actors,
+    )
+    raise SystemExit(0 if trusted else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/backlog/closed/005_public_repo_workflow_hardening.md
+++ b/docs/backlog/closed/005_public_repo_workflow_hardening.md
@@ -1,0 +1,23 @@
+# Public Repo Workflow Hardening
+
+## Goal
+Make the repository safe to switch to public visibility without breaking trusted Jules automation or owner/Jules auto-merge behavior.
+
+## Scope
+- Restrict privileged workflow behavior to trusted same-repo actors.
+- Prevent privileged `workflow_run` jobs from checking out untrusted PR head code.
+- Keep issue-triggered Jules sessions working for trusted actors.
+- Preserve the single active Jules session limit for this repository.
+
+## Checklist
+- [x] Add shared trusted-actor/trusted-PR evaluation logic.
+- [x] Harden `report-ci-failure.yml`.
+- [x] Harden `manage-pr-lifecycle.yml`.
+- [x] Keep `run-agent.yml` and `jules.py` aligned with trusted actor rules.
+- [x] Update docs and verify with tests/lint.
+
+## Verification
+- `uv run pytest`
+- `uv run ruff check automation_trust.py jules.py tests .github/scripts`
+- Confirmed trusted owner-created issues still flow through `run-agent.yml` and `jules.py`.
+- Confirmed single-session enforcement remains in both workflow concurrency and the Jules busy-session check.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -17,6 +17,7 @@ This repository integrates **Google Jules** via its REST API and hosts a web int
 - **Single Active Session:** Only one non-terminal Jules session may be active for this repository at a time.
 - **Queued Retry:** When a new issue arrives while Jules is busy, the issue is queued and retried automatically until it starts.
 - **Owner-Gated Issue Entry:** Public issue/comment events only start or steer Jules when they come from the repository owner.
+- **Trusted PR Automation:** Privileged PR follow-up automation only acts on same-repo PRs from the repository owner or extra logins listed in the `JULES_TRUSTED_ACTORS` repository variable.
 
 ### 3. Web Downloader Interface
 - Users submit one or more video URLs via a web UI.

--- a/tests/test_automation_trust.py
+++ b/tests/test_automation_trust.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from automation_trust import is_trusted_actor, is_trusted_pr, parse_trusted_actors
+
+
+def test_parse_trusted_actors_supports_json_and_owner_default():
+    trusted = parse_trusted_actors('["app/google-jules", "someone-else"]', "RepoOwner")
+
+    assert trusted == {"repoowner", "app/google-jules", "someone-else"}
+
+
+def test_parse_trusted_actors_supports_csv():
+    trusted = parse_trusted_actors("app/google-jules, teammate ", "RepoOwner")
+
+    assert trusted == {"repoowner", "app/google-jules", "teammate"}
+
+
+def test_is_trusted_actor_allows_owner_and_allowlisted_actor():
+    assert is_trusted_actor("RepoOwner", "repoowner", "")
+    assert is_trusted_actor("app/google-jules", "repoowner", '["app/google-jules"]')
+    assert not is_trusted_actor("random-user", "repoowner", '["app/google-jules"]')
+
+
+def test_is_trusted_pr_requires_same_repo_and_trusted_author():
+    assert is_trusted_pr(
+        author_login="app/google-jules",
+        head_owner_login="RepoOwner",
+        is_cross_repository=False,
+        repo_owner="repoowner",
+        trusted_actors_raw='["app/google-jules"]',
+    )
+    assert not is_trusted_pr(
+        author_login="random-user",
+        head_owner_login="RepoOwner",
+        is_cross_repository=False,
+        repo_owner="repoowner",
+        trusted_actors_raw='["app/google-jules"]',
+    )
+    assert not is_trusted_pr(
+        author_login="app/google-jules",
+        head_owner_login="fork-owner",
+        is_cross_repository=True,
+        repo_owner="repoowner",
+        trusted_actors_raw='["app/google-jules"]',
+    )

--- a/tests/test_jules_bridge.py
+++ b/tests/test_jules_bridge.py
@@ -24,11 +24,6 @@ def test_is_session_busy_only_for_non_terminal_states():
     assert not jules.is_session_busy({"state": "FAILED"})
 
 
-def test_is_repo_owner_matches_case_insensitively():
-    assert jules.is_repo_owner("JjGroenendijk", "jjgroenendijk")
-    assert not jules.is_repo_owner("someone-else", "jjgroenendijk")
-
-
 @patch("jules.post_issue_comment")
 @patch("jules.issue_has_queue_comment", return_value=False)
 def test_queue_issue_posts_single_queue_comment(mock_has_queue_comment, mock_post_issue_comment):


### PR DESCRIPTION
## Summary
- harden privileged workflow automation so the repository can be made public more safely
- restrict PR follow-up automation to trusted same-repo PRs only
- keep owner-triggered Jules issue sessions working with the existing single-session limit

## What changed
- add `automation_trust.py` to evaluate trusted actors and trusted same-repo PRs
- harden `report-ci-failure.yml` so it checks out the default branch instead of PR head code and skips untrusted or cross-repo PRs
- harden `manage-pr-lifecycle.yml` so auto-merge only runs for trusted same-repo PRs
- set `persist-credentials: false` on workflow checkouts where the token does not need to be written into git config
- make `verify-codebase.yml` explicitly read-only for contents
- document the hardening and verification in backlog/docs

## Trusted actor model
- issue-triggered Jules remains gated to the dynamic repository owner
- privileged PR follow-up automation trusts only same-repo PRs from the repository owner or logins listed in the optional `JULES_TRUSTED_ACTORS` repository variable
- this preserves owner/Jules automation while blocking public fork PRs from reaching privileged follow-up workflows

## Jules behavior check
- owner-created issues still create or queue a Jules session through `run-agent.yml`
- repository-level single-session enforcement remains in place via:
  - workflow concurrency in `run-agent.yml`
  - the busy-session check in `jules.py`

## Verification
- `uv run pytest`
- `uv run ruff check automation_trust.py jules.py tests .github/scripts`

## Follow-up after merge
Repository settings still need to be tightened outside of code before switching visibility:
- set default workflow permissions to read-only
- restrict allowed actions if desired
- require SHA pinning if desired

This PR removes the code-level blockers that were still present on `main`, especially the privileged `workflow_run` job that checked out PR head code.