### PR TITLE
Add video resolution selection

### DIFF
--- a/docs/backlog/closed/006_resolution_selection.md
+++ b/docs/backlog/closed/006_resolution_selection.md
@@ -1,0 +1,3 @@
+# Resolution Selection
+
+Add the ability for users to select video resolution for downloads. Options should include Best Available, 4K, QHD, FHD, and HD. This requires updating the frontend UI, API endpoint, and yt-dlp arguments construction.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -91,6 +92,13 @@ export async function POST(request: Request) {
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
 
+  let resolution: string | undefined = undefined;
+  if (mode === "video" && typeof body.resolution === "string") {
+    if (body.resolution === "best" || /^(\d+p)$/.test(body.resolution)) {
+      resolution = body.resolution;
+    }
+  }
+
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
@@ -100,6 +108,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +128,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +151,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -43,6 +43,7 @@ export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
+  const [resolution, setResolution] = useState("best");
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
@@ -52,6 +53,7 @@ export function DownloaderDashboard() {
     setUrl(record.url);
     setMode(record.mode);
     setIncludePlaylist(record.includePlaylist);
+    setResolution(record.resolution ?? "best");
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -91,6 +93,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution: mode === "video" ? resolution : undefined,
         }),
       });
 
@@ -194,6 +197,23 @@ export function DownloaderDashboard() {
             <option value="audio">Audio (MP3)</option>
           </select>
 
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Resolution</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
+
           <label className="checkbox-row" htmlFor="playlist">
             <input
               id="playlist"
@@ -254,6 +274,9 @@ export function DownloaderDashboard() {
                   </span>
                   <span>{formatTimestamp(record.createdAt)}</span>
                   <span>{record.mode}</span>
+                  {record.mode === "video" && record.resolution && record.resolution !== "best" && (
+                    <span className="resolution-badge">{record.resolution}</span>
+                  )}
                   <button
                     type="button"
                     className="retry-btn"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -9,6 +9,7 @@ export interface DownloadRecord {
   url: string;
   mode: "video" | "audio";
   includePlaylist: boolean;
+  resolution?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -83,7 +84,12 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    if (request.resolution && request.resolution !== "best") {
+      const height = request.resolution.replace("p", "");
+      args.push("--format", `bestvideo[height<=${height}]+bestaudio/best[height<=${height}]`);
+    } else {
+      args.push("--format", "bv*+ba/b");
+    }
   }
 
   args.push(request.url);

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1676,6 +1677,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2122,6 +2124,7 @@
       "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2132,6 +2135,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2688,6 +2692,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3015,6 +3020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3580,6 +3586,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3698,6 +3705,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3944,6 +3952,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4363,6 +4372,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5870,6 +5880,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5879,6 +5890,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6593,6 +6605,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6752,6 +6765,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6868,6 +6882,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6976,6 +6991,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7232,6 +7248,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/tests/archive-store.test.ts
+++ b/website/tests/archive-store.test.ts
@@ -69,6 +69,7 @@ describe("Archive Store Tests", () => {
         url: "http://example.com",
         mode: "video",
         includePlaylist: false,
+        resolution: "best",
         status: "completed",
         files: [fileName],
         logTail: "log",
@@ -103,6 +104,7 @@ describe("Archive Store Tests", () => {
         url: "http://example.com",
         mode: "video",
         includePlaylist: false,
+        resolution: "best",
         status: "completed",
         files: ["missing.mp4"],
         logTail: "log",
@@ -128,6 +130,7 @@ describe("Archive Store Tests", () => {
         url: "http://example.com",
         mode: "video",
         includePlaylist: false,
+        resolution: "best",
         status: "completed",
         files: ["../outside.txt"], // Malicious path
         logTail: "log",

--- a/website/tests/delete_record.spec.ts
+++ b/website/tests/delete_record.spec.ts
@@ -9,6 +9,7 @@ test.describe("Delete Record", () => {
         url: "http://example.com/video",
         mode: "video",
         includePlaylist: false,
+        resolution: "best",
         status: "completed",
         files: ["video.mp4"],
         logTail: "Success",

--- a/website/tests/home.spec.ts
+++ b/website/tests/home.spec.ts
@@ -34,6 +34,7 @@ test("submits a download and displays history", async ({ page }) => {
     url: "https://example.com/watch?v=123",
     mode: "audio",
     includePlaylist: true,
+    resolution: undefined,
     status: "completed",
     files: ["creator/2026-02-08/example.mp3"],
     logTail: "done",

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+test("displays and submits resolution for video downloads", async ({ page }) => {
+  let requestBody: Record<string, unknown> | null = null;
+  const postedRecord = {
+    id: "run-res",
+    createdAt: "2026-02-08T10:00:00.000Z",
+    url: "https://example.com/watch?v=123",
+    mode: "video",
+    includePlaylist: false,
+    resolution: "1080p",
+    status: "completed",
+    files: ["creator/2026-02-08/example.mp4"],
+    logTail: "done",
+  };
+
+  await page.route("**/api/downloads", async (route) => {
+    const method = route.request().method();
+
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ records: requestBody ? [postedRecord] : [] }),
+      });
+      return;
+    }
+
+    requestBody = JSON.parse(route.request().postData() ?? "{}");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        record: postedRecord,
+      }),
+    });
+  });
+
+  await page.goto("/");
+
+  // Verify visibility logic
+  await expect(page.getByLabel("Resolution")).toBeVisible();
+
+  await page.getByLabel("Mode").selectOption("audio");
+  await expect(page.getByLabel("Resolution")).toBeHidden();
+
+  await page.getByLabel("Mode").selectOption("video");
+  await expect(page.getByLabel("Resolution")).toBeVisible();
+
+  // Submit form
+  await page.getByLabel("Video URL").fill("https://example.com/watch?v=123");
+  await page.getByLabel("Resolution").selectOption("1080p");
+  await page.getByRole("button", { name: "Download and Archive" }).click();
+
+  await expect(page.getByTestId("status-text")).toHaveText("Download complete.");
+  await expect(page.getByTestId("history-list")).toContainText("1080p");
+
+  expect(requestBody).toEqual({
+    url: "https://example.com/watch?v=123",
+    mode: "video",
+    includePlaylist: false,
+    resolution: "1080p",
+  });
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,38 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds explicit resolution format for video", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "1080p",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bestvideo[height<=1080]+bestaudio/best[height<=1080]");
+  });
+
+  it("uses default format if resolution is 'best'", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "best",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bv*+ba/b");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Implements a new feature to allow users to select their preferred video resolution when downloading videos.

- Added an optional `resolution` field to `DownloadRequest` and `DownloadRecord`.
- Updated `buildYtDlpArgs` to construct `bestvideo[height<=X]+bestaudio/best[height<=X]` strings for valid resolutions (e.g., 4K, 1440p, 1080p, 720p).
- Updated the `/api/downloads` route to validate and apply the new parameter.
- Enhanced the UI in `downloader-dashboard.tsx` with a resolution dropdown, history badges, and integrated it into the retry handler.
- Created `resolution.spec.ts` E2E test and updated `ytdlp.test.ts`.
- Moved `docs/backlog/open/006_resolution_selection.md` to the closed folder.

---
*PR created automatically by Jules for task [14006416060862394047](https://jules.google.com/task/14006416060862394047) started by @jjgroenendijk*