### PR TITLE
feat: allow custom yt-dlp filename patterns

### DIFF
--- a/docs/backlog/closed/006_custom_filename.md
+++ b/docs/backlog/closed/006_custom_filename.md
@@ -1,0 +1,2 @@
+# Allow custom yt-dlp file names
+Allow users to define a custom file name pattern for their downloads in the web interface.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    customFilename?: string;
   };
 
   if (!body.url) {
@@ -91,6 +92,17 @@ export async function POST(request: Request) {
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
 
+  let customFilename: string | undefined = undefined;
+  if (typeof body.customFilename === "string" && body.customFilename.trim() !== "") {
+    customFilename = body.customFilename.trim();
+    if (customFilename.startsWith("/") || customFilename.startsWith("\\") || customFilename.includes("..")) {
+      return NextResponse.json(
+        { error: "Invalid custom filename pattern." },
+        { status: 400 },
+      );
+    }
+  }
+
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
@@ -100,6 +112,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      customFilename,
     },
     paths,
   );
@@ -119,6 +132,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      customFilename,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +155,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      customFilename,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -11,6 +11,7 @@ interface DownloadRecord {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  customFilename?: string;
   status: DownloadStatus;
   files: string[];
   logTail: string;
@@ -43,6 +44,7 @@ export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
+  const [customFilename, setCustomFilename] = useState("");
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
@@ -52,6 +54,7 @@ export function DownloaderDashboard() {
     setUrl(record.url);
     setMode(record.mode);
     setIncludePlaylist(record.includePlaylist);
+    setCustomFilename(record.customFilename ?? "");
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -91,6 +94,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          customFilename,
         }),
       });
 
@@ -193,6 +197,16 @@ export function DownloaderDashboard() {
             <option value="video">Best Video + Audio</option>
             <option value="audio">Audio (MP3)</option>
           </select>
+
+          <label htmlFor="custom-filename">Custom Filename Pattern (Optional)</label>
+          <input
+            id="custom-filename"
+            name="custom-filename"
+            type="text"
+            placeholder="e.g., %(title)s.%(ext)s"
+            value={customFilename}
+            onChange={(event) => setCustomFilename(event.target.value)}
+          />
 
           <label className="checkbox-row" htmlFor="playlist">
             <input

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -9,6 +9,7 @@ export interface DownloadRecord {
   url: string;
   mode: "video" | "audio";
   includePlaylist: boolean;
+  customFilename?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  customFilename?: string;
 }
 
 export interface DataPaths {
@@ -58,6 +59,10 @@ export function buildYtDlpArgs(
   request: DownloadRequest,
   paths: DataPaths,
 ): string[] {
+  const outputTemplate = request.customFilename && request.customFilename.trim() !== ""
+    ? request.customFilename.trim()
+    : "%(uploader|unknown_uploader)s/%(upload_date>%Y-%m-%d,unknown_date)s/%(title).160B [%(id)s].%(ext)s";
+
   const args = [
     "--newline",
     "--no-warnings",
@@ -66,7 +71,7 @@ export function buildYtDlpArgs(
     "--paths",
     paths.downloadsDir,
     "--output",
-    "%(uploader|unknown_uploader)s/%(upload_date>%Y-%m-%d,unknown_date)s/%(title).160B [%(id)s].%(ext)s",
+    outputTemplate,
     "--print",
     "after_move:filepath",
     "--write-info-json",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1676,6 +1677,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2122,6 +2124,7 @@
       "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2132,6 +2135,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2688,6 +2692,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3015,6 +3020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3580,6 +3586,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3698,6 +3705,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3944,6 +3952,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4363,6 +4372,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5870,6 +5880,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5879,6 +5890,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6593,6 +6605,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6752,6 +6765,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6868,6 +6882,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6976,6 +6991,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7232,6 +7248,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/tests/home.spec.ts
+++ b/website/tests/home.spec.ts
@@ -65,6 +65,7 @@ test("submits a download and displays history", async ({ page }) => {
   await page.getByLabel("Video URL").fill("https://example.com/watch?v=123");
   await page.getByLabel("Mode").selectOption("audio");
   await page.getByLabel("Download full playlist").check();
+  await page.getByLabel("Custom Filename Pattern (Optional)").fill("%(title)s.%(ext)s");
   await page.getByRole("button", { name: "Download and Archive" }).click();
 
   await expect(page.getByTestId("status-text")).toHaveText("Download complete.");
@@ -74,5 +75,6 @@ test("submits a download and displays history", async ({ page }) => {
     url: "https://example.com/watch?v=123",
     mode: "audio",
     includePlaylist: true,
+    customFilename: "%(title)s.%(ext)s",
   });
 });

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,23 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds custom filename flag", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=custom",
+        mode: "video",
+        includePlaylist: false,
+        customFilename: "custom-template-%(id)s.%(ext)s",
+      },
+      paths,
+    );
+
+    const outputIndex = args.indexOf("--output");
+    expect(outputIndex).toBeGreaterThan(-1);
+    expect(args[outputIndex + 1]).toBe("custom-template-%(id)s.%(ext)s");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
This pull request implements the "Custom Filename Pattern" feature for yt-dlp downloads. Users can now optionally define their own output naming structure (e.g. `%(title)s.%(ext)s`) via the web interface.

Key changes:
- Added `customFilename` to `DownloadRequest` and `DownloadRecord` types.
- Implemented frontend input for the custom filename with state management and retry inclusion.
- Ensured backend API validation securely sanitizes the custom filename pattern, preventing traversal attacks (`..`) and absolute path exploits.
- Updated the yt-dlp builder to construct custom `--output` flags when provided.
- Added comprehensive unit testing for builder outputs.
- Expanded end-to-end tests to verify payload delivery including the custom pattern.

---
*PR created automatically by Jules for task [281705580966379074](https://jules.google.com/task/281705580966379074) started by @jjgroenendijk*