### PR TITLE
Improve Jules automation recovery

### DIFF
--- a/.github/scripts/detect_merge_conflicts.py
+++ b/.github/scripts/detect_merge_conflicts.py
@@ -110,7 +110,10 @@ def check_and_report_conflict(pr, repo_full_name):
         return
 
     print(f"Creating conflict issue for PR #{number}...")
-    body = f"The PR #{number} has merge conflicts. A Jules session is requested to resolve this."
+    body = (
+        f"The PR #{number} has merge conflicts. A Jules session is requested to resolve this.\n\n"
+        f"<!-- pr-automation:pr={number} -->"
+    )
     issue_number = create_conflict_issue(repo_full_name, title_search, body)
 
     if issue_number:

--- a/.github/scripts/reconcile_prs.py
+++ b/.github/scripts/reconcile_prs.py
@@ -6,9 +6,16 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
 PASSING_CHECK_STATES = {"SUCCESS", "PASS", "SKIPPED", "SKIP", "NEUTRAL"}
 SESSION_ID_PATTERN = re.compile(r"\*\*Session ID:\*\* `(sessions/[^`]+)`")
+PR_AUTOMATION_MARKER_PATTERN = re.compile(r"<!--\s*pr-automation:pr=(\d+)\s*-->")
+QUEUE_MARKER_PATTERN = re.compile(r"<!--\s*jules-queue\s*-->")
+CI_FAILURE_TITLE_PATTERN = re.compile(r"^CI Failure: PR #(\d+)$")
+MERGE_CONFLICT_TITLE_PATTERN = re.compile(r"^Merge Conflict: PR #(\d+)$")
+GENERIC_AUTOMATION_TITLE_PATTERN = re.compile(r"^PR Automation: PR #(\d+) requires attention$")
+QUEUE_RETRY_INTERVAL = timedelta(hours=1)
 
 
 @dataclass
@@ -16,8 +23,29 @@ class ReconcileStats:
     scanned: int = 0
     merged: int = 0
     issues_created: int = 0
+    issues_closed: int = 0
     sessions_triggered: int = 0
     errors: int = 0
+
+
+@dataclass
+class IssueJulesState:
+    has_session: bool = False
+    queued: bool = False
+    last_queue_comment_at: datetime | None = None
+
+    def should_retry(self, now: datetime | None = None):
+        if self.has_session:
+            return False
+
+        if not self.queued:
+            return True
+
+        if self.last_queue_comment_at is None:
+            return True
+
+        current_time = now or datetime.now(timezone.utc)
+        return current_time - self.last_queue_comment_at >= QUEUE_RETRY_INTERVAL
 
 
 class GitHubCLI:
@@ -25,6 +53,7 @@ class GitHubCLI:
         self.repo = repo
         self.dry_run = dry_run
         self._issues_cache = None
+        self._issue_state_cache: dict[int, IssueJulesState] = {}
 
     def run(self, command: list[str], check: bool = True):
         result = subprocess.run(command, capture_output=True, text=True)
@@ -168,6 +197,14 @@ class GitHubCLI:
                 return int(issue["number"])
         return None
 
+    def list_open_automation_issues(self):
+        issues = []
+        for issue in self._list_open_issues():
+            if linked_pr_number_for_issue(issue) is None:
+                continue
+            issues.append(issue)
+        return issues
+
     def create_issue(self, title: str, body: str):
         if self.dry_run:
             print(f"[dry-run] Would create issue: {title}")
@@ -201,7 +238,59 @@ class GitHubCLI:
             self._issues_cache.append({"number": issue_number, "title": title})
         return issue_number
 
-    def issue_has_jules_session(self, issue_number: int):
+    def find_open_issue_numbers_for_pr(self, pr_number: int):
+        titles = {
+            ci_failure_issue_title_for_pr(pr_number),
+            issue_title_for_pr(pr_number),
+            conflict_issue_title_for_pr(pr_number),
+        }
+
+        issue_numbers: list[int] = []
+        for issue in self._list_open_issues():
+            issue_number = int(issue["number"])
+            title = issue.get("title", "")
+            if title in titles:
+                issue_numbers.append(issue_number)
+                continue
+
+            marker = PR_AUTOMATION_MARKER_PATTERN.search(str(issue.get("body", "")))
+            if marker and int(marker.group(1)) == pr_number:
+                issue_numbers.append(issue_number)
+
+        return sorted(set(issue_numbers))
+
+    def close_issue(self, issue_number: int, reason: str):
+        if self.dry_run:
+            print(f"[dry-run] Would close issue #{issue_number}")
+            return True
+
+        result = self.run(
+            [
+                "gh",
+                "issue",
+                "close",
+                str(issue_number),
+                "--repo",
+                self.repo,
+                "--comment",
+                reason,
+            ],
+            check=False,
+        )
+        if not result or result.returncode != 0:
+            return False
+
+        if self._issues_cache is not None:
+            self._issues_cache = [
+                issue for issue in self._issues_cache if int(issue.get("number", -1)) != issue_number
+            ]
+
+        return True
+
+    def get_issue_jules_state(self, issue_number: int):
+        if issue_number in self._issue_state_cache:
+            return self._issue_state_cache[issue_number]
+
         comments = self.run_json(
             [
                 "gh",
@@ -210,13 +299,29 @@ class GitHubCLI:
             ]
         )
         if not isinstance(comments, list):
-            return False
+            state = IssueJulesState()
+            self._issue_state_cache[issue_number] = state
+            return state
 
+        state = IssueJulesState()
         for comment in comments:
             body = comment.get("body", "")
             if SESSION_ID_PATTERN.search(body):
-                return True
-        return False
+                state.has_session = True
+
+            if QUEUE_MARKER_PATTERN.search(body):
+                state.queued = True
+                created_at = parse_github_timestamp(comment.get("created_at") or comment.get("createdAt"))
+                if created_at and (
+                    state.last_queue_comment_at is None or created_at > state.last_queue_comment_at
+                ):
+                    state.last_queue_comment_at = created_at
+
+        self._issue_state_cache[issue_number] = state
+        return state
+
+    def issue_has_jules_session(self, issue_number: int):
+        return self.get_issue_jules_state(issue_number).has_session
 
     def trigger_jules_session(self, issue_number: int):
         if self.dry_run:
@@ -238,9 +343,57 @@ class GitHubCLI:
         )
         return bool(result and result.returncode == 0)
 
+    def drop_issue_from_cache(self, issue_number: int):
+        self._issue_state_cache.pop(issue_number, None)
+
 
 def issue_title_for_pr(pr_number: int):
     return f"PR Automation: PR #{pr_number} requires attention"
+
+
+def ci_failure_issue_title_for_pr(pr_number: int):
+    return f"CI Failure: PR #{pr_number}"
+
+
+def conflict_issue_title_for_pr(pr_number: int):
+    return f"Merge Conflict: PR #{pr_number}"
+
+
+def parse_github_timestamp(value: str | None):
+    if not value:
+        return None
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def linked_pr_number_for_issue(issue: dict):
+    marker = PR_AUTOMATION_MARKER_PATTERN.search(str(issue.get("body", "")))
+    if marker:
+        return int(marker.group(1))
+
+    title = str(issue.get("title", ""))
+    for pattern in (
+        CI_FAILURE_TITLE_PATTERN,
+        MERGE_CONFLICT_TITLE_PATTERN,
+        GENERIC_AUTOMATION_TITLE_PATTERN,
+    ):
+        match = pattern.match(title)
+        if match:
+            return int(match.group(1))
+
+    return None
+
+
+def canonical_issue_number(issues: list[dict], issue_states: dict[int, IssueJulesState]):
+    def sort_key(issue: dict):
+        issue_number = int(issue["number"])
+        state = issue_states.get(issue_number, IssueJulesState())
+        return (0 if state.has_session else 1, issue_number)
+
+    return int(min(issues, key=sort_key)["number"])
 
 
 def normalize_check_state(check: dict):
@@ -301,12 +454,14 @@ class PrReconciler:
 
     def reconcile(self, pr_numbers: list[int] | None = None):
         numbers = pr_numbers or self.client.list_open_pr_numbers()
+        processed_pr_numbers = set(numbers)
         if not numbers:
             print("No open PRs to process.")
-            return self.stats
+        else:
+            for pr_number in numbers:
+                self.reconcile_pr(pr_number)
 
-        for pr_number in numbers:
-            self.reconcile_pr(pr_number)
+        self.recover_automation_issues(processed_pr_numbers)
 
         return self.stats
 
@@ -327,8 +482,10 @@ class PrReconciler:
         return mergeable
 
     def _ensure_issue_and_session(self, pr: dict, reasons: list[str], blocked: list[dict]):
-        title = issue_title_for_pr(int(pr["number"]))
-        issue_number = self.client.find_open_issue_by_title(title)
+        pr_number = int(pr["number"])
+        title = issue_title_for_pr(pr_number)
+        linked_issue_numbers = self.client.find_open_issue_numbers_for_pr(pr_number)
+        issue_number = linked_issue_numbers[0] if linked_issue_numbers else None
 
         if issue_number is None:
             body = build_issue_body(pr, reasons, blocked)
@@ -344,13 +501,87 @@ class PrReconciler:
             print(f"Issue #{issue_number} already has a Jules session.")
             return
 
-        print(f"Issue #{issue_number} has no Jules session. Triggering run-agent workflow.")
+        self._trigger_issue_if_ready(issue_number)
+
+    def _close_linked_issues(self, pr_number: int, reason: str):
+        issue_numbers = self.client.find_open_issue_numbers_for_pr(pr_number)
+        if not issue_numbers:
+            return
+
+        for issue_number in issue_numbers:
+            if self.client.close_issue(issue_number, reason):
+                self.stats.issues_closed += 1
+                print(f"Closed issue #{issue_number} for PR #{pr_number}")
+                continue
+
+            self.stats.errors += 1
+            print(f"Failed to close issue #{issue_number} for PR #{pr_number}")
+
+    def _close_issue(self, issue_number: int, reason: str):
+        if self.client.close_issue(issue_number, reason):
+            self.client.drop_issue_from_cache(issue_number)
+            self.stats.issues_closed += 1
+            print(f"Closed issue #{issue_number}")
+            return True
+
+        self.stats.errors += 1
+        print(f"Failed to close issue #{issue_number}")
+        return False
+
+    def _trigger_issue_if_ready(self, issue_number: int):
+        state = self.client.get_issue_jules_state(issue_number)
+        if not state.should_retry():
+            print(f"Issue #{issue_number} is queued for retry and not ready yet.")
+            return
+
+        print(f"Issue #{issue_number} is ready for Jules recovery. Triggering run-agent workflow.")
         if self.client.trigger_jules_session(issue_number):
             self.stats.sessions_triggered += 1
+            self.client.drop_issue_from_cache(issue_number)
             return
 
         print(f"Failed to trigger Jules for issue #{issue_number}")
         self.stats.errors += 1
+
+    def recover_automation_issues(self, processed_pr_numbers: set[int]):
+        grouped: dict[int, list[dict]] = {}
+        for issue in self.client.list_open_automation_issues():
+            pr_number = linked_pr_number_for_issue(issue)
+            if pr_number is None:
+                continue
+            grouped.setdefault(pr_number, []).append(issue)
+
+        for pr_number, issues in sorted(grouped.items()):
+            issue_states = {
+                int(issue["number"]): self.client.get_issue_jules_state(int(issue["number"]))
+                for issue in issues
+            }
+            canonical_number = canonical_issue_number(issues, issue_states)
+
+            for issue in sorted(issues, key=lambda item: int(item["number"])):
+                issue_number = int(issue["number"])
+                if issue_number == canonical_number:
+                    continue
+                self._close_issue(
+                    issue_number,
+                    (
+                        f"Closing automatically as a duplicate automation issue for PR #{pr_number}. "
+                        f"Issue #{canonical_number} remains the canonical tracker."
+                    ),
+                )
+
+            if pr_number in processed_pr_numbers:
+                continue
+
+            pr = self.client.get_pr(pr_number)
+            if not pr or pr.get("state") != "OPEN":
+                self._close_issue(
+                    canonical_number,
+                    f"Closing automatically because PR #{pr_number} is no longer open.",
+                )
+                continue
+
+            self._trigger_issue_if_ready(canonical_number)
 
     def reconcile_pr(self, pr_number: int):
         self.stats.scanned += 1
@@ -362,6 +593,10 @@ class PrReconciler:
 
         if pr.get("state") != "OPEN":
             print(f"PR #{pr_number} is {pr.get('state')}. Skipping.")
+            self._close_linked_issues(
+                pr_number,
+                f"Closing automatically because PR #{pr_number} is {str(pr.get('state')).lower()}.",
+            )
             return
 
         mergeable = self._resolve_mergeable(pr_number, str(pr.get("mergeable") or "UNKNOWN"))
@@ -382,6 +617,10 @@ class PrReconciler:
         if self.client.merge_pr(pr_number):
             self.stats.merged += 1
             print(f"Merged PR #{pr_number}")
+            self._close_linked_issues(
+                pr_number,
+                f"Closing automatically because PR #{pr_number} has been merged.",
+            )
             return
 
         print(f"Merge failed for PR #{pr_number}; collecting diagnostics.")
@@ -446,7 +685,8 @@ def main():
     print(
         "Summary: "
         f"scanned={stats.scanned}, merged={stats.merged}, "
-        f"issues_created={stats.issues_created}, sessions_triggered={stats.sessions_triggered}, "
+        f"issues_created={stats.issues_created}, issues_closed={stats.issues_closed}, "
+        f"sessions_triggered={stats.sessions_triggered}, "
         f"errors={stats.errors}"
     )
 

--- a/.github/workflows/nightly-pr-reconciliation.yml
+++ b/.github/workflows/nightly-pr-reconciliation.yml
@@ -1,8 +1,8 @@
-name: Nightly PR Reconciliation
+name: PR Reconciliation
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "15 * * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/report-ci-failure.yml
+++ b/.github/workflows/report-ci-failure.yml
@@ -102,6 +102,8 @@ jobs:
             echo "\`\`\`" >> issue_body.md
             echo "" >> issue_body.md
             echo "[View Full Logs](https://github.com/${{ github.repository }}/actions/runs/$RUN_ID)" >> issue_body.md
+            echo "" >> issue_body.md
+            echo "<!-- pr-automation:pr=$PR_NUMBER -->" >> issue_body.md
 
             ISSUE_NUMBER=$(jq -Rs --arg title "$TITLE" '{title: $title, body: .}' issue_body.md \
               | gh api \

--- a/README.md
+++ b/README.md
@@ -88,5 +88,7 @@ The app will be available on `http://localhost:3000`.
 
 - `Verify Codebase` runs Python lint/tests and website lint/unit/e2e tests.
 - `Run Agent` reacts to new issues/comments and also polls hourly to drain queued issues when the repo's active Jules session finishes.
-- `Nightly PR Reconciliation` runs every midnight UTC to merge healthy open PRs, create issues for blocked PRs, and recover missing Jules sessions.
+- `PR Reconciliation` runs hourly to merge healthy open PRs, retry queued Jules automation issues, deduplicate stale automation tickets, recover missing Jules sessions, and close linked automation issues after successful merges.
+- `Manage PR Lifecycle` closes linked merge/conflict automation issues immediately after an automated merge succeeds.
+- `Close PR Automation Issues` runs on merged PR close events to close linked automation issues for manual merges.
 - `Publish Container` builds and publishes the single runtime image to GHCR.

--- a/docs/backlog/closed/005_pr_automation_recovery.md
+++ b/docs/backlog/closed/005_pr_automation_recovery.md
@@ -1,0 +1,15 @@
+# 005 Recover Queued Jules Automation Issues
+
+## What
+Improve PR automation recovery so Jules-created CI failure and merge-conflict issues do not remain open indefinitely when Jules is busy or when duplicate automation issues are created.
+
+## Why
+The repository already creates automation issues for blocked PRs, but recovery is too weak. Queued issues can sit open for too long, and duplicate automation issues accumulate for the same PR.
+
+## Progress
+- [x] Open backlog item for automation recovery and deduplication.
+- [x] Extend PR reconciliation to recover queued automation issues.
+- [x] Close duplicate automation issues for the same PR.
+- [x] Increase reconciliation cadence so queued work is retried promptly.
+- [x] Add unit tests for queued issue recovery and duplicate cleanup.
+- [x] Update README documentation for the recovery behavior.

--- a/tests/test_reconcile_prs.py
+++ b/tests/test_reconcile_prs.py
@@ -17,16 +17,22 @@ class FakeClient:
         merge_result=False,
         existing_issue=None,
         has_session=False,
+        trigger_result=True,
     ):
         self.pr = pr
         self.checks = checks
         self.merge_result = merge_result
         self.existing_issue = existing_issue
         self.has_session = has_session
+        self.trigger_result = trigger_result
 
         self.merged = []
         self.created_issues = []
         self.triggered_sessions = []
+        self.open_issue_numbers_for_pr = []
+        self.closed_issues = []
+        self.issue_states = {}
+        self.automation_issues = []
 
     def list_open_pr_numbers(self):
         return [self.pr["number"]]
@@ -53,9 +59,25 @@ class FakeClient:
     def issue_has_jules_session(self, issue_number):
         return self.has_session
 
+    def get_issue_jules_state(self, issue_number):
+        return self.issue_states.get(issue_number, reconcile_prs.IssueJulesState())
+
     def trigger_jules_session(self, issue_number):
         self.triggered_sessions.append(issue_number)
+        return self.trigger_result
+
+    def find_open_issue_numbers_for_pr(self, pr_number):
+        return self.open_issue_numbers_for_pr
+
+    def close_issue(self, issue_number, reason):
+        self.closed_issues.append((issue_number, reason))
         return True
+
+    def list_open_automation_issues(self):
+        return self.automation_issues
+
+    def drop_issue_from_cache(self, issue_number):
+        return None
 
 
 def test_blocking_checks_detects_non_passing_states():
@@ -70,7 +92,7 @@ def test_blocking_checks_detects_non_passing_states():
     assert [check["name"] for check in blocked] == ["tests", "e2e"]
 
 
-def test_conflicting_pr_creates_issue():
+def test_conflicting_pr_creates_issue_and_triggers_jules():
     client = FakeClient(
         pr={
             "number": 42,
@@ -107,12 +129,38 @@ def test_existing_issue_without_session_triggers_jules():
         existing_issue=123,
         has_session=False,
     )
+    client.open_issue_numbers_for_pr = [123]
 
     reconciler = reconcile_prs.PrReconciler(client)
     reconciler.reconcile_pr(7)
 
     assert reconciler.stats.sessions_triggered == 1
     assert client.triggered_sessions == [123]
+
+
+def test_session_trigger_failure_increments_errors():
+    client = FakeClient(
+        pr={
+            "number": 21,
+            "title": "Fix CI",
+            "url": "https://example/pr/21",
+            "mergeable": "MERGEABLE",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[{"name": "ci", "state": "FAILURE"}],
+        existing_issue=555,
+        has_session=False,
+        trigger_result=False,
+    )
+    client.open_issue_numbers_for_pr = [555]
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(21)
+
+    assert reconciler.stats.sessions_triggered == 0
+    assert reconciler.stats.errors == 1
+    assert client.triggered_sessions == [555]
 
 
 def test_mergeable_and_passing_pr_is_merged():
@@ -135,3 +183,137 @@ def test_mergeable_and_passing_pr_is_merged():
     assert reconciler.stats.merged == 1
     assert client.merged == [9]
     assert not client.created_issues
+
+
+def test_merge_success_closes_linked_issues():
+    client = FakeClient(
+        pr={
+            "number": 12,
+            "title": "Resolve conflict",
+            "url": "https://example/pr/12",
+            "mergeable": "MERGEABLE",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[{"name": "ci", "state": "SUCCESS"}],
+        merge_result=True,
+    )
+    client.open_issue_numbers_for_pr = [201, 202]
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(12)
+
+    assert reconciler.stats.issues_closed == 2
+    assert [issue for issue, _ in client.closed_issues] == [201, 202]
+
+
+def test_non_open_pr_closes_linked_issues_without_merge_attempt():
+    client = FakeClient(
+        pr={
+            "number": 88,
+            "title": "Already merged",
+            "url": "https://example/pr/88",
+            "mergeable": "UNKNOWN",
+            "isDraft": False,
+            "state": "MERGED",
+        },
+        checks=[],
+        merge_result=False,
+    )
+    client.open_issue_numbers_for_pr = [303]
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(88)
+
+    assert reconciler.stats.merged == 0
+    assert reconciler.stats.issues_closed == 1
+    assert client.merged == []
+    assert client.closed_issues and client.closed_issues[0][0] == 303
+
+
+def test_queued_issue_retries_when_queue_comment_is_stale():
+    client = FakeClient(
+        pr={
+            "number": 13,
+            "title": "Fix queued automation",
+            "url": "https://example/pr/13",
+            "mergeable": "MERGEABLE",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[{"name": "ci", "state": "FAILURE"}],
+        existing_issue=413,
+        has_session=False,
+    )
+    client.open_issue_numbers_for_pr = [413]
+    client.issue_states[413] = reconcile_prs.IssueJulesState(
+        queued=True,
+        last_queue_comment_at=reconcile_prs.datetime.now(reconcile_prs.timezone.utc)
+        - reconcile_prs.QUEUE_RETRY_INTERVAL
+        - reconcile_prs.timedelta(minutes=5),
+    )
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(13)
+
+    assert client.triggered_sessions == [413]
+    assert reconciler.stats.sessions_triggered == 1
+
+
+def test_duplicate_automation_issues_are_closed_during_recovery():
+    client = FakeClient(
+        pr={
+            "number": 51,
+            "title": "Conflicting PR",
+            "url": "https://example/pr/51",
+            "mergeable": "CONFLICTING",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[],
+        existing_issue=601,
+        has_session=False,
+    )
+    client.automation_issues = [
+        {"number": 601, "title": "Merge Conflict: PR #51", "body": ""},
+        {"number": 602, "title": "Merge Conflict: PR #51", "body": ""},
+    ]
+    client.issue_states[601] = reconcile_prs.IssueJulesState(has_session=True)
+    client.issue_states[602] = reconcile_prs.IssueJulesState()
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile()
+
+    assert reconciler.stats.issues_closed == 1
+    assert client.closed_issues == [
+        (
+            602,
+            "Closing automatically as a duplicate automation issue for PR #51. "
+            "Issue #601 remains the canonical tracker.",
+        )
+    ]
+
+
+def test_closed_pr_canonical_automation_issue_is_closed_during_recovery():
+    client = FakeClient(
+        pr={
+            "number": 71,
+            "title": "Merged already",
+            "url": "https://example/pr/71",
+            "mergeable": "UNKNOWN",
+            "isDraft": False,
+            "state": "MERGED",
+        },
+        checks=[],
+        merge_result=False,
+    )
+    client.automation_issues = [
+        {"number": 701, "title": "CI Failure: PR #71", "body": "<!-- pr-automation:pr=71 -->"}
+    ]
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.recover_automation_issues(processed_pr_numbers=set())
+
+    assert client.closed_issues == [
+        (701, "Closing automatically because PR #71 is no longer open.")
+    ]


### PR DESCRIPTION
## Summary
- retry queued Jules automation issues during PR reconciliation
- deduplicate automation issues per PR and close stale ones
- add automation markers to CI failure and merge conflict issues

## Verification
- uv run pytest tests/test_reconcile_prs.py
- uv run python -m py_compile .github/scripts/reconcile_prs.py .github/scripts/detect_merge_conflicts.py jules.py