### PR TITLE
feat: Add resolution selection for video downloads

### DIFF
--- a/docs/backlog/closed/resolution-selection.md
+++ b/docs/backlog/closed/resolution-selection.md
@@ -1,0 +1,13 @@
+# Feature: Resolution Selection
+
+## Description
+Allow users to select a preferred maximum video resolution when downloading videos.
+This provides users with better control over download size and quality.
+
+## Requirements
+- Add a dropdown for resolution selection (Best Available, 4K, QHD, FHD, HD).
+- Only show the resolution dropdown when the download mode is "video".
+- Update API endpoints to accept and validate the resolution parameter.
+- Update yt-dlp argument builder to map the resolution to the correct format string.
+- Store the selected resolution in the download history and display it as a badge.
+- Include unit tests and E2E tests for the new functionality.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: Request) {
     url?: string;
     mode?: unknown;
     includePlaylist?: unknown;
+    resolution?: unknown;
   };
 
   if (!body.url) {
@@ -91,6 +92,15 @@ export async function POST(request: Request) {
   const mode = parseMode(body.mode);
   const includePlaylist = parsePlaylistFlag(body.includePlaylist);
 
+  let resolution: string | undefined = undefined;
+  if (mode === "video") {
+    if (typeof body.resolution === "string" && (body.resolution === "best" || /^(\d+p)$/.test(body.resolution))) {
+      resolution = body.resolution;
+    } else {
+      resolution = "best";
+    }
+  }
+
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
@@ -100,6 +110,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
     },
     paths,
   );
@@ -119,6 +130,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -141,6 +153,7 @@ export async function POST(request: Request) {
       url: validatedUrl,
       mode,
       includePlaylist,
+      resolution,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -237,6 +237,16 @@ button:disabled {
   border-color: rgba(255, 115, 115, 0.4);
 }
 
+.resolution-badge {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  border-radius: 6px;
+  padding: 0.15rem 0.4rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-muted);
+}
+
 .retry-btn {
   margin-left: auto;
   width: auto;

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -11,6 +11,7 @@ interface DownloadRecord {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
   status: DownloadStatus;
   files: string[];
   logTail: string;
@@ -43,6 +44,7 @@ export function DownloaderDashboard() {
   const [url, setUrl] = useState("");
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
+  const [resolution, setResolution] = useState<string>("best");
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
@@ -52,6 +54,11 @@ export function DownloaderDashboard() {
     setUrl(record.url);
     setMode(record.mode);
     setIncludePlaylist(record.includePlaylist);
+    if (record.resolution) {
+      setResolution(record.resolution);
+    } else {
+      setResolution("best");
+    }
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -91,6 +98,7 @@ export function DownloaderDashboard() {
           url,
           mode,
           includePlaylist,
+          resolution: mode === "video" ? resolution : undefined,
         }),
       });
 
@@ -194,6 +202,23 @@ export function DownloaderDashboard() {
             <option value="audio">Audio (MP3)</option>
           </select>
 
+          {mode === "video" && (
+            <>
+              <label htmlFor="resolution">Max Resolution</label>
+              <select
+                id="resolution"
+                value={resolution}
+                onChange={(event) => setResolution(event.target.value)}
+              >
+                <option value="best">Best Available</option>
+                <option value="2160p">4K (2160p)</option>
+                <option value="1440p">QHD (1440p)</option>
+                <option value="1080p">FHD (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </>
+          )}
+
           <label className="checkbox-row" htmlFor="playlist">
             <input
               id="playlist"
@@ -254,6 +279,9 @@ export function DownloaderDashboard() {
                   </span>
                   <span>{formatTimestamp(record.createdAt)}</span>
                   <span>{record.mode}</span>
+                  {record.mode === "video" && record.resolution && record.resolution !== "best" && (
+                    <span className="resolution-badge">{record.resolution}</span>
+                  )}
                   <button
                     type="button"
                     className="retry-btn"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -9,6 +9,7 @@ export interface DownloadRecord {
   url: string;
   mode: "video" | "audio";
   includePlaylist: boolean;
+  resolution?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -6,6 +6,7 @@ export interface DownloadRequest {
   url: string;
   mode: DownloadMode;
   includePlaylist: boolean;
+  resolution?: string;
 }
 
 export interface DataPaths {
@@ -83,7 +84,12 @@ export function buildYtDlpArgs(
   if (request.mode === "audio") {
     args.push("--extract-audio", "--audio-format", "mp3", "--audio-quality", "0");
   } else {
-    args.push("--format", "bv*+ba/b");
+    if (request.resolution && request.resolution !== "best") {
+      const res = request.resolution.replace("p", "");
+      args.push("--format", `bestvideo[height<=${res}]+bestaudio/best[height<=${res}]`);
+    } else {
+      args.push("--format", "bv*+ba/b");
+    }
   }
 
   args.push(request.url);

--- a/website/tests/resolution.spec.ts
+++ b/website/tests/resolution.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+test("submits a download with a specific resolution and displays history", async ({ page }) => {
+  let requestBody: Record<string, unknown> | null = null;
+  const postedRecord = {
+    id: "run-2",
+    createdAt: "2026-02-08T10:05:00.000Z",
+    url: "https://example.com/watch?v=456",
+    mode: "video",
+    includePlaylist: false,
+    resolution: "720p",
+    status: "completed",
+    files: ["creator/2026-02-08/example-video.mp4"],
+    logTail: "done",
+  };
+
+  await page.route("**/api/downloads", async (route) => {
+    const method = route.request().method();
+
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ records: requestBody ? [postedRecord] : [] }),
+      });
+      return;
+    }
+
+    requestBody = JSON.parse(route.request().postData() ?? "{}");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        record: postedRecord,
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByLabel("Video URL").fill("https://example.com/watch?v=456");
+
+  // Make sure we are in video mode
+  await page.getByLabel("Mode").selectOption("video");
+
+  // The resolution dropdown should be visible now
+  await expect(page.getByLabel("Max Resolution")).toBeVisible();
+
+  // Select HD (720p)
+  await page.getByLabel("Max Resolution").selectOption("720p");
+
+  // Uncheck playlist
+  await page.getByLabel("Download full playlist").uncheck();
+
+  // Submit
+  await page.getByRole("button", { name: "Download and Archive" }).click();
+
+  await expect(page.getByTestId("status-text")).toHaveText("Download complete.");
+  await expect(page.getByTestId("history-list")).toContainText("creator/2026-02-08/example-video.mp4");
+
+  // Verify the resolution badge is displayed in the history list
+  await expect(page.locator(".resolution-badge")).toHaveText("720p");
+
+  expect(requestBody).toEqual({
+    url: "https://example.com/watch?v=456",
+    mode: "video",
+    includePlaylist: false,
+    resolution: "720p",
+  });
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -54,6 +54,22 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("--no-playlist");
   });
+
+  it("builds video flags with specific resolution", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        resolution: "720p",
+      },
+      paths,
+    );
+
+    expect(args).toContain("--format");
+    expect(args).toContain("bestvideo[height<=720]+bestaudio/best[height<=720]");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Added a feature to select the maximum resolution for video downloads. Resolves backlog item resolution-selection.md.

---
*PR created automatically by Jules for task [2440479659639223687](https://jules.google.com/task/2440479659639223687) started by @jjgroenendijk*