### PR TITLE
Add GitHub-managed scheduled autonomous PR flow

### DIFF
--- a/.github/scripts/schedule_autonomous_pr.py
+++ b/.github/scripts/schedule_autonomous_pr.py
@@ -1,0 +1,315 @@
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+AUTONOMOUS_MARKER = "<!-- autonomous-schedule -->"
+AUTONOMOUS_TITLE = "Scheduled Autonomous Development"
+SESSION_ID_PATTERN = re.compile(r"\*\*Session ID:\*\* `(sessions/[^`]+)`")
+
+
+@dataclass
+class ScheduleStats:
+    issues_created: int = 0
+    sessions_triggered: int = 0
+    skipped_for_open_prs: int = 0
+    skipped_for_cooldown: int = 0
+    errors: int = 0
+
+
+def parse_github_timestamp(value: str | None):
+    if not value:
+        return None
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+class GitHubCLI:
+    def __init__(self, repo: str, dry_run: bool = False):
+        self.repo = repo
+        self.dry_run = dry_run
+
+    def run(self, command: list[str], check: bool = True):
+        result = subprocess.run(command, capture_output=True, text=True)
+        if check and result.returncode != 0:
+            printable = " ".join(command)
+            print(f"Command failed: {printable}")
+            if result.stderr:
+                print(result.stderr.strip())
+            return None
+        return result
+
+    def run_json(self, command: list[str]):
+        result = self.run(command, check=True)
+        if result is None:
+            return None
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            return None
+
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            printable = " ".join(command)
+            print(f"Failed to decode JSON output: {printable}")
+            return None
+
+    def list_open_pr_numbers(self):
+        data = self.run_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number",
+            ]
+        )
+        if not isinstance(data, list):
+            return []
+        return [int(pr["number"]) for pr in data]
+
+    def list_open_issues(self):
+        data = self.run_json(["gh", "api", f"repos/{self.repo}/issues?state=open&per_page=100"])
+        if not isinstance(data, list):
+            return []
+        return [issue for issue in data if "pull_request" not in issue]
+
+    def find_autonomous_issue(self):
+        for issue in self.list_open_issues():
+            body = str(issue.get("body", ""))
+            if AUTONOMOUS_MARKER in body:
+                return int(issue["number"])
+
+        for issue in self.list_open_issues():
+            if issue.get("title") == AUTONOMOUS_TITLE:
+                return int(issue["number"])
+
+        return None
+
+    def create_issue(self, title: str, body: str):
+        if self.dry_run:
+            print(f"[dry-run] Would create issue: {title}")
+            return 0
+
+        result = self.run(
+            [
+                "gh",
+                "api",
+                f"repos/{self.repo}/issues",
+                "-X",
+                "POST",
+                "-f",
+                f"title={title}",
+                "-f",
+                f"body={body}",
+                "-q",
+                ".number",
+            ],
+            check=True,
+        )
+        if result is None:
+            return None
+
+        issue_number_text = result.stdout.strip()
+        if not issue_number_text.isdigit():
+            return None
+
+        return int(issue_number_text)
+
+    def get_issue_comments(self, issue_number: int):
+        data = self.run_json(
+            [
+                "gh",
+                "api",
+                f"repos/{self.repo}/issues/{issue_number}/comments?per_page=100",
+            ]
+        )
+        if not isinstance(data, list):
+            return []
+        return data
+
+    def trigger_jules_session(self, issue_number: int):
+        if self.dry_run:
+            print(f"[dry-run] Would trigger run-agent.yml for issue #{issue_number}")
+            return True
+
+        result = self.run(
+            [
+                "gh",
+                "workflow",
+                "run",
+                "run-agent.yml",
+                "--repo",
+                self.repo,
+                "-f",
+                f"issue_number={issue_number}",
+            ],
+            check=False,
+        )
+        return bool(result and result.returncode == 0)
+
+
+def build_issue_body():
+    lines = [
+        "This reusable issue exists so GitHub Actions can start scheduled Jules runs through the normal issue-backed bridge.",
+        "",
+        "On each run:",
+        "1. Follow `AGENTS.md` exactly.",
+        "2. Prioritize `docs/troubleshooting/open/`, then `docs/backlog/open/`, then unsatisfied requirements.",
+        "3. If no work is open, propose and implement one small high-value improvement for the yt-dlp web interface.",
+        "4. Deliver the change through the normal Jules `AUTO_CREATE_PR` flow with tests and docs updates where applicable.",
+        "",
+        AUTONOMOUS_MARKER,
+    ]
+    return "\n".join(lines)
+
+
+class AutonomousScheduler:
+    def __init__(self, client: GitHubCLI, cooldown: timedelta, force: bool = False):
+        self.client = client
+        self.cooldown = cooldown
+        self.force = force
+        self.stats = ScheduleStats()
+
+    def ensure_issue(self):
+        issue_number = self.client.find_autonomous_issue()
+        if issue_number is not None:
+            return issue_number
+
+        issue_number = self.client.create_issue(AUTONOMOUS_TITLE, build_issue_body())
+        if issue_number is None:
+            self.stats.errors += 1
+            print("Failed to create scheduled autonomy issue.")
+            return None
+
+        self.stats.issues_created += 1
+        print(f"Created scheduled autonomy issue #{issue_number}")
+        return issue_number
+
+    def latest_session_comment_at(self, issue_number: int):
+        latest = None
+        for comment in self.client.get_issue_comments(issue_number):
+            body = str(comment.get("body", ""))
+            if not SESSION_ID_PATTERN.search(body):
+                continue
+
+            created_at = parse_github_timestamp(comment.get("created_at") or comment.get("createdAt"))
+            if created_at and (latest is None or created_at > latest):
+                latest = created_at
+
+        return latest
+
+    def should_skip_for_cooldown(self, issue_number: int, now: datetime | None = None):
+        if self.force:
+            return False
+
+        latest = self.latest_session_comment_at(issue_number)
+        if latest is None:
+            return False
+
+        current_time = now or datetime.now(timezone.utc)
+        return current_time - latest < self.cooldown
+
+    def run(self):
+        open_prs = self.client.list_open_pr_numbers()
+        if open_prs:
+            self.stats.skipped_for_open_prs += 1
+            print(f"Skipping scheduled autonomy because open PRs exist: {open_prs}")
+            return self.stats
+
+        issue_number = self.ensure_issue()
+        if issue_number is None:
+            return self.stats
+
+        if self.should_skip_for_cooldown(issue_number):
+            self.stats.skipped_for_cooldown += 1
+            print(f"Skipping scheduled autonomy because issue #{issue_number} is inside cooldown.")
+            return self.stats
+
+        print(f"Triggering scheduled Jules session via issue #{issue_number}")
+        if self.client.trigger_jules_session(issue_number):
+            self.stats.sessions_triggered += 1
+            return self.stats
+
+        self.stats.errors += 1
+        print(f"Failed to trigger scheduled Jules session for issue #{issue_number}")
+        return self.stats
+
+
+def resolve_repo(args_repo: str | None):
+    if args_repo:
+        return args_repo
+
+    from_env = os.environ.get("GITHUB_REPOSITORY")
+    if from_env:
+        return from_env
+
+    result = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+
+    return None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Trigger scheduled autonomous Jules runs through the issue-backed bridge."
+    )
+    parser.add_argument("--repo", help="GitHub repo in owner/name format")
+    parser.add_argument(
+        "--cooldown-hours",
+        type=float,
+        default=18,
+        help="Do not trigger if the tracker issue received a session comment more recently than this.",
+    )
+    parser.add_argument("--force", action="store_true", help="Ignore cooldown checks")
+    parser.add_argument("--dry-run", action="store_true", help="Print intended changes only")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo = resolve_repo(args.repo)
+    if not repo:
+        print("Could not resolve repository. Set --repo or GITHUB_REPOSITORY.")
+        return 1
+
+    client = GitHubCLI(repo=repo, dry_run=args.dry_run)
+    scheduler = AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=args.cooldown_hours),
+        force=args.force,
+    )
+    stats = scheduler.run()
+
+    print(
+        "Summary: "
+        f"issues_created={stats.issues_created}, "
+        f"sessions_triggered={stats.sessions_triggered}, "
+        f"skipped_for_open_prs={stats.skipped_for_open_prs}, "
+        f"skipped_for_cooldown={stats.skipped_for_cooldown}, "
+        f"errors={stats.errors}"
+    )
+    return 1 if stats.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scheduled-autonomous-pr.yml
+++ b/.github/workflows/scheduled-autonomous-pr.yml
@@ -1,0 +1,30 @@
+name: Scheduled Autonomous PR
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: scheduled-autonomous-pr
+  cancel-in-progress: false
+
+jobs:
+  schedule-autonomous-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: read
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Trigger issue-backed scheduled autonomy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 .github/scripts/schedule_autonomous_pr.py

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The automation will:
 
 Issue-triggered Jules entry stays owner-only even if you configure extra trusted PR actors.
 
+For recurring autonomous work, use the repository workflow in `.github/workflows/scheduled-autonomous-pr.yml`, not a schedule configured inside Jules. The workflow reuses a canonical GitHub issue and dispatches `run-agent.yml`, which keeps the session on the `AUTO_CREATE_PR` path this repository already reconciles.
+
 ## Trusted automation model
 
 Privileged `workflow_run` follow-up automation only acts on trusted pull requests:
@@ -87,6 +89,7 @@ The app will be available on `http://localhost:3000`.
 ## CI/CD
 
 - `Verify Codebase` runs Python lint/tests and website lint/unit/e2e tests.
+- `Scheduled Autonomous PR` runs daily to create or reuse the canonical autonomous-development issue and trigger an issue-backed Jules session when the repo is idle.
 - `Run Agent` reacts to new issues/comments and also polls hourly to drain queued issues when the repo's active Jules session finishes.
 - `PR Reconciliation` runs hourly to merge healthy open PRs, retry queued Jules automation issues, deduplicate stale automation tickets, recover missing Jules sessions, and close linked automation issues after successful merges.
 - `Manage PR Lifecycle` closes linked merge/conflict automation issues immediately after an automated merge succeeds.

--- a/docs/backlog/closed/006_scheduled_autonomous_prs.md
+++ b/docs/backlog/closed/006_scheduled_autonomous_prs.md
@@ -1,0 +1,19 @@
+# 006 Scheduled Autonomous PR Creation
+
+## What
+Add a GitHub-managed schedule that creates or reuses an issue-backed Jules run so autonomous work still goes through `AUTO_CREATE_PR`.
+
+## Why
+Scheduled tasks created inside Jules do not reliably post pull requests for this repository. The repo already knows how to create Jules sessions from GitHub issues, so the scheduler should trigger that path instead of relying on Jules-native scheduling.
+
+## Progress
+- [x] Open backlog item for scheduled autonomous PR creation.
+- [x] Implement a scheduler script that reuses a canonical automation issue and triggers `run-agent.yml`.
+- [x] Add a scheduled workflow with overlap guards so only one autonomous run is active at a time.
+- [x] Add unit tests for the scheduler behavior.
+- [x] Update requirements and README with the GitHub-managed scheduling model.
+- [x] Verify locally and move this item to `docs/backlog/closed/`.
+
+## Verification
+- `uv run pytest tests/test_schedule_autonomous_pr.py`
+- `uv run pytest tests/test_reconcile_prs.py`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -10,6 +10,7 @@ This repository integrates **Google Jules** via its REST API and hosts a web int
 - It listens for GitHub issue events.
 - It executes `jules.py` to process the event and call the Jules API.
 - Public issue/comment entry stays gated to the dynamic repository owner.
+- Scheduled autonomous development must also enter through GitHub-managed workflows so sessions stay issue-backed and PR-capable.
 
 ### 2. Google Jules API Integration
 - **Authentication:** Uses `GOOGLE_JULES_API` key stored in repository secrets.
@@ -20,6 +21,7 @@ This repository integrates **Google Jules** via its REST API and hosts a web int
 - **Owner-Gated Issue Entry:** Public issue/comment events only start or steer Jules when they come from the repository owner.
 - **Trusted PR Automation:** Privileged PR follow-up automation only acts on trusted same-repo PRs.
 - **Configurable Trusted Actors:** The repository owner is trusted by default, and optional extra logins may be provided through `JULES_TRUSTED_ACTORS`.
+- **Scheduled Recovery:** Recurring autonomous runs must reuse the same issue-backed flow instead of relying on Jules-native scheduling.
 
 ### 3. Web Downloader Interface
 - Users submit one or more video URLs via a web UI.

--- a/tests/test_schedule_autonomous_pr.py
+++ b/tests/test_schedule_autonomous_pr.py
@@ -1,0 +1,170 @@
+from datetime import datetime, timedelta, timezone
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "scripts" / "schedule_autonomous_pr.py"
+)
+SPEC = spec_from_file_location("schedule_autonomous_pr", MODULE_PATH)
+schedule_autonomous_pr = module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(schedule_autonomous_pr)
+
+
+class FakeClient:
+    def __init__(
+        self,
+        open_pr_numbers=None,
+        issue_number=None,
+        create_issue_number=501,
+        comments=None,
+        trigger_result=True,
+    ):
+        self.open_pr_numbers = open_pr_numbers or []
+        self.issue_number = issue_number
+        self.create_issue_number = create_issue_number
+        self.comments = comments or []
+        self.trigger_result = trigger_result
+
+        self.created_issues = []
+        self.triggered_sessions = []
+
+    def list_open_pr_numbers(self):
+        return self.open_pr_numbers
+
+    def find_autonomous_issue(self):
+        return self.issue_number
+
+    def create_issue(self, title, body):
+        self.created_issues.append((title, body))
+        return self.create_issue_number
+
+    def get_issue_comments(self, issue_number):
+        return self.comments
+
+    def trigger_jules_session(self, issue_number):
+        self.triggered_sessions.append(issue_number)
+        return self.trigger_result
+
+
+def test_creates_issue_and_triggers_session_when_repo_is_idle():
+    client = FakeClient(issue_number=None, create_issue_number=701)
+
+    scheduler = schedule_autonomous_pr.AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=18),
+    )
+    stats = scheduler.run()
+
+    assert stats.issues_created == 1
+    assert stats.sessions_triggered == 1
+    assert client.created_issues
+    assert client.triggered_sessions == [701]
+
+
+def test_skips_when_open_prs_exist():
+    client = FakeClient(open_pr_numbers=[14], issue_number=701)
+
+    scheduler = schedule_autonomous_pr.AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=18),
+    )
+    stats = scheduler.run()
+
+    assert stats.skipped_for_open_prs == 1
+    assert stats.sessions_triggered == 0
+    assert client.triggered_sessions == []
+
+
+def test_reuses_existing_issue_when_outside_cooldown():
+    client = FakeClient(
+        issue_number=808,
+        comments=[
+            {
+                "body": "- **Session ID:** `sessions/123`",
+                "created_at": "2026-03-01T06:00:00Z",
+            }
+        ],
+    )
+
+    scheduler = schedule_autonomous_pr.AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=18),
+    )
+    should_skip = scheduler.should_skip_for_cooldown(
+        808, now=datetime(2026, 3, 3, 6, 0, tzinfo=timezone.utc)
+    )
+
+    assert not should_skip
+
+    stats = scheduler.run()
+
+    assert stats.issues_created == 0
+    assert stats.sessions_triggered == 1
+    assert client.triggered_sessions == [808]
+
+
+def test_skips_when_recent_session_comment_exists():
+    client = FakeClient(
+        issue_number=909,
+        comments=[
+            {
+                "body": "- **Session ID:** `sessions/999`",
+                "created_at": "2026-03-03T01:30:00Z",
+            }
+        ],
+    )
+
+    scheduler = schedule_autonomous_pr.AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=18),
+    )
+    should_skip = scheduler.should_skip_for_cooldown(
+        909, now=datetime(2026, 3, 3, 6, 0, tzinfo=timezone.utc)
+    )
+
+    assert should_skip
+
+    stats = scheduler.run()
+
+    assert stats.skipped_for_cooldown == 1
+    assert stats.sessions_triggered == 0
+    assert client.triggered_sessions == []
+
+
+def test_force_bypasses_cooldown():
+    client = FakeClient(
+        issue_number=1001,
+        comments=[
+            {
+                "body": "- **Session ID:** `sessions/1001`",
+                "created_at": "2026-03-03T05:30:00Z",
+            }
+        ],
+    )
+
+    scheduler = schedule_autonomous_pr.AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=18),
+        force=True,
+    )
+    stats = scheduler.run()
+
+    assert stats.skipped_for_cooldown == 0
+    assert stats.sessions_triggered == 1
+    assert client.triggered_sessions == [1001]
+
+
+def test_trigger_failure_increments_errors():
+    client = FakeClient(issue_number=1101, trigger_result=False)
+
+    scheduler = schedule_autonomous_pr.AutonomousScheduler(
+        client=client,
+        cooldown=timedelta(hours=18),
+    )
+    stats = scheduler.run()
+
+    assert stats.errors == 1
+    assert stats.sessions_triggered == 0
+    assert client.triggered_sessions == [1101]


### PR DESCRIPTION
## Summary
- add a GitHub-managed scheduler that creates or reuses a canonical issue and dispatches the existing Jules bridge
- skip scheduled autonomy while PRs are open and apply a cooldown based on the latest session comment
- document the GitHub-managed scheduling model and cover the scheduler with unit tests

## Testing
- uv run pytest tests/test_schedule_autonomous_pr.py
- uv run pytest tests/test_reconcile_prs.py