### PR TITLE
fix: prevent PR reconciliation script from treating QUEUED checks as failures

### DIFF
--- a/.github/scripts/reconcile_prs.py
+++ b/.github/scripts/reconcile_prs.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 PASSING_CHECK_STATES = {"SUCCESS", "PASS", "SKIPPED", "SKIP", "NEUTRAL"}
+PENDING_CHECK_STATES = {"QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED"}
 SESSION_ID_PATTERN = re.compile(r"\*\*Session ID:\*\* `(sessions/[^`]+)`")
 PR_AUTOMATION_MARKER_PATTERN = re.compile(r"<!--\s*pr-automation:pr=(\d+)\s*-->")
 QUEUE_MARKER_PATTERN = re.compile(r"<!--\s*jules-queue\s*-->")
@@ -404,11 +405,19 @@ def is_passing_check_state(state: str):
     return state.upper() in PASSING_CHECK_STATES
 
 
+def is_pending_check_state(state: str):
+    return state.upper() in PENDING_CHECK_STATES
+
+
+def pending_checks(checks: list[dict]):
+    return [c for c in checks if is_pending_check_state(normalize_check_state(c))]
+
+
 def blocking_checks(checks: list[dict]):
     blocked = []
     for check in checks:
         state = normalize_check_state(check)
-        if not is_passing_check_state(state):
+        if not is_passing_check_state(state) and not is_pending_check_state(state):
             blocked.append(check)
     return blocked
 
@@ -602,6 +611,7 @@ class PrReconciler:
         mergeable = self._resolve_mergeable(pr_number, str(pr.get("mergeable") or "UNKNOWN"))
         checks = self.client.get_pr_checks(pr_number)
         blocked = blocking_checks(checks)
+        pending = pending_checks(checks)
 
         reasons = []
         if str(mergeable).upper() == "CONFLICTING":
@@ -612,6 +622,10 @@ class PrReconciler:
 
         if reasons:
             self._ensure_issue_and_session(pr, reasons, blocked)
+            return
+
+        if pending:
+            print(f"PR #{pr_number} has pending checks. Skipping.")
             return
 
         if self.client.merge_pr(pr_number):

--- a/tests/test_reconcile_prs.py
+++ b/tests/test_reconcile_prs.py
@@ -89,7 +89,41 @@ def test_blocking_checks_detects_non_passing_states():
 
     blocked = reconcile_prs.blocking_checks(checks)
 
-    assert [check["name"] for check in blocked] == ["tests", "e2e"]
+    assert [check["name"] for check in blocked] == ["tests"]
+
+
+def test_pending_checks_detects_pending_states():
+    checks = [
+        {"name": "lint", "state": "SUCCESS"},
+        {"name": "tests", "state": "FAILURE"},
+        {"name": "e2e", "state": "PENDING"},
+        {"name": "build", "state": "QUEUED"},
+    ]
+
+    pending = reconcile_prs.pending_checks(checks)
+
+    assert [check["name"] for check in pending] == ["e2e", "build"]
+
+
+def test_pending_pr_is_skipped():
+    client = FakeClient(
+        pr={
+            "number": 10,
+            "title": "Pending checks",
+            "url": "https://example/pr/10",
+            "mergeable": "MERGEABLE",
+            "isDraft": False,
+            "state": "OPEN",
+        },
+        checks=[{"name": "ci", "state": "QUEUED"}],
+    )
+
+    reconciler = reconcile_prs.PrReconciler(client)
+    reconciler.reconcile_pr(10)
+
+    assert reconciler.stats.merged == 0
+    assert not client.created_issues
+    assert not client.triggered_sessions
 
 
 def test_conflicting_pr_creates_issue_and_triggers_jules():


### PR DESCRIPTION
This PR fixes a bug in `.github/scripts/reconcile_prs.py` where pending CI checks (e.g., `QUEUED`, `IN_PROGRESS`) were being treated as blockers. 

When a PR is opened, the automated reconciliation script runs and checks the PR's status. Previously, it assumed any check not explicitly passing was failing, which caused it to incorrectly create an automation issue complaining about "Non-passing checks" when checks were actually just starting.

Changes:
- Defined `PENDING_CHECK_STATES` (`QUEUED`, `IN_PROGRESS`, `PENDING`, `WAITING`, `REQUESTED`).
- Updated `blocking_checks()` to ignore pending states.
- Added logic to explicitly skip PR processing (no merge, no automation issue) if there are any pending checks.
- Updated unit tests in `tests/test_reconcile_prs.py` to verify this behavior.

---
*PR created automatically by Jules for task [15557607812050426937](https://jules.google.com/task/15557607812050426937) started by @jjgroenendijk*