### PR TITLE
feat: Add support for custom output filenames

### DIFF
--- a/docs/backlog/closed/custom-filename.md
+++ b/docs/backlog/closed/custom-filename.md
@@ -1,0 +1,15 @@
+# Add support for custom output filenames
+
+## Problem
+Currently, the yt-dlp web interface uses a default output filename template (`%(uploader|unknown_uploader)s/%(upload_date>%Y-%m-%d,unknown_date)s/%(title).160B [%(id)s].%(ext)s`). Users may want to specify their own custom output format for downloaded files.
+
+## Solution
+Allow users to provide a `customFilename` string in the UI. If provided, use it as the `--output` argument for yt-dlp instead of the default.
+
+### Implementation details
+1. Update `website/lib/ytdlp.ts` to accept `customFilename` and apply it to `--output` args. Add basic validation to avoid directory traversal (e.g. `..` or `/` at the beginning).
+2. Update `website/lib/archive-store.ts` to save `customFilename` in the `DownloadRecord`.
+3. Update `website/app/api/downloads/route.ts` to parse and validate `customFilename` from the request.
+4. Update `website/components/downloader-dashboard.tsx` to add a text input for `customFilename`, submit it, handle retries, and display a `.custom-filename-badge` if a custom filename was used.
+5. Update `website/app/globals.css` with the `.custom-filename-badge` styling.
+6. Add unit tests and Playwright E2E tests for the new functionality.

--- a/website/app/api/downloads/route.ts
+++ b/website/app/api/downloads/route.ts
@@ -73,6 +73,7 @@ export async function POST(request: Request) {
     mode?: unknown;
     includePlaylist?: unknown;
     resolution?: unknown;
+    customFilename?: unknown;
   };
 
   if (!body.url) {
@@ -101,6 +102,17 @@ export async function POST(request: Request) {
     }
   }
 
+  let customFilename: string | undefined = undefined;
+  if (typeof body.customFilename === "string" && body.customFilename.trim() !== "") {
+    customFilename = body.customFilename.trim();
+    if (customFilename.includes("..") || customFilename.includes("/") || customFilename.includes("\\") || customFilename.startsWith(".")) {
+      return NextResponse.json(
+        { error: "Invalid custom filename. Directory traversal characters or absolute paths are not allowed." },
+        { status: 400 }
+      );
+    }
+  }
+
   const dataDir = resolveDataDir();
   const paths = getDataPaths(dataDir);
   await ensureDataStorage(paths);
@@ -111,6 +123,7 @@ export async function POST(request: Request) {
       mode,
       includePlaylist,
       resolution,
+      customFilename,
     },
     paths,
   );
@@ -131,6 +144,7 @@ export async function POST(request: Request) {
       mode,
       includePlaylist,
       resolution,
+      customFilename,
       status: code === 0 ? "completed" : "failed",
       files,
       logTail: output.slice(-6000),
@@ -154,6 +168,7 @@ export async function POST(request: Request) {
       mode,
       includePlaylist,
       resolution,
+      customFilename,
       status: "failed",
       files: [],
       logTail: error instanceof Error ? error.message : "Unknown error",

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -247,6 +247,16 @@ button:disabled {
   color: var(--text-muted);
 }
 
+.custom-filename-badge {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  border-radius: 6px;
+  padding: 0.15rem 0.4rem;
+  background: rgba(139, 230, 199, 0.15);
+  border: 1px solid rgba(47, 199, 161, 0.3);
+  color: var(--accent-main);
+}
+
 .retry-btn {
   margin-left: auto;
   width: auto;

--- a/website/components/downloader-dashboard.tsx
+++ b/website/components/downloader-dashboard.tsx
@@ -12,6 +12,7 @@ interface DownloadRecord {
   mode: DownloadMode;
   includePlaylist: boolean;
   resolution?: string;
+  customFilename?: string;
   status: DownloadStatus;
   files: string[];
   logTail: string;
@@ -45,6 +46,7 @@ export function DownloaderDashboard() {
   const [mode, setMode] = useState<DownloadMode>("video");
   const [includePlaylist, setIncludePlaylist] = useState(false);
   const [resolution, setResolution] = useState<string>("best");
+  const [customFilename, setCustomFilename] = useState("");
   const [history, setHistory] = useState<DownloadRecord[]>([]);
   const [storageUsage, setStorageUsage] = useState<number>(0);
   const [isRunning, setIsRunning] = useState(false);
@@ -58,6 +60,11 @@ export function DownloaderDashboard() {
       setResolution(record.resolution);
     } else {
       setResolution("best");
+    }
+    if (record.customFilename) {
+      setCustomFilename(record.customFilename);
+    } else {
+      setCustomFilename("");
     }
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
@@ -99,6 +106,7 @@ export function DownloaderDashboard() {
           mode,
           includePlaylist,
           resolution: mode === "video" ? resolution : undefined,
+          customFilename: customFilename.trim() !== "" ? customFilename : undefined,
         }),
       });
 
@@ -219,6 +227,16 @@ export function DownloaderDashboard() {
             </>
           )}
 
+          <label htmlFor="custom-filename">Custom Filename (Optional)</label>
+          <input
+            id="custom-filename"
+            name="custom-filename"
+            type="text"
+            placeholder="e.g. MyVideo.%(ext)s"
+            value={customFilename}
+            onChange={(event) => setCustomFilename(event.target.value)}
+          />
+
           <label className="checkbox-row" htmlFor="playlist">
             <input
               id="playlist"
@@ -281,6 +299,9 @@ export function DownloaderDashboard() {
                   <span>{record.mode}</span>
                   {record.mode === "video" && record.resolution && record.resolution !== "best" && (
                     <span className="resolution-badge">{record.resolution}</span>
+                  )}
+                  {record.customFilename && (
+                    <span className="custom-filename-badge">Custom Name</span>
                   )}
                   <button
                     type="button"

--- a/website/lib/archive-store.ts
+++ b/website/lib/archive-store.ts
@@ -10,6 +10,7 @@ export interface DownloadRecord {
   mode: "video" | "audio";
   includePlaylist: boolean;
   resolution?: string;
+  customFilename?: string;
   status: "completed" | "failed";
   files: string[];
   logTail: string;

--- a/website/lib/ytdlp.ts
+++ b/website/lib/ytdlp.ts
@@ -7,6 +7,7 @@ export interface DownloadRequest {
   mode: DownloadMode;
   includePlaylist: boolean;
   resolution?: string;
+  customFilename?: string;
 }
 
 export interface DataPaths {
@@ -59,6 +60,26 @@ export function buildYtDlpArgs(
   request: DownloadRequest,
   paths: DataPaths,
 ): string[] {
+  let outputTemplate = "%(uploader|unknown_uploader)s/%(upload_date>%Y-%m-%d,unknown_date)s/%(title).160B [%(id)s].%(ext)s";
+
+  if (request.customFilename && request.customFilename.trim() !== "") {
+    let sanitized = request.customFilename.trim();
+    // Prevent absolute paths and directory traversal
+    sanitized = sanitized.replace(/\\/g, "/");
+
+    // Iteratively remove all relative path components
+    let previous;
+    do {
+      previous = sanitized;
+      sanitized = sanitized.replace(/(^|\/)\.+(\/|$)/g, "/");
+      sanitized = sanitized.replace(/^\/+/, "");
+    } while (sanitized !== previous);
+
+    if (sanitized !== "") {
+       outputTemplate = sanitized;
+    }
+  }
+
   const args = [
     "--newline",
     "--no-warnings",
@@ -67,7 +88,7 @@ export function buildYtDlpArgs(
     "--paths",
     paths.downloadsDir,
     "--output",
-    "%(uploader|unknown_uploader)s/%(upload_date>%Y-%m-%d,unknown_date)s/%(title).160B [%(id)s].%(ext)s",
+    outputTemplate,
     "--print",
     "after_move:filepath",
     "--write-info-json",

--- a/website/tests/custom_filename.spec.ts
+++ b/website/tests/custom_filename.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Custom Filename selection", () => {
+  test("allows selecting a custom filename, sends it in request, and displays badge", async ({ page }) => {
+    // Mock the initial GET request for history load
+    await page.route("/api/downloads", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            records: [],
+            storageUsage: 0,
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/");
+
+    const urlInput = page.getByLabel("Video URL");
+    await urlInput.fill("https://example.com/watch?v=custom-filename");
+
+    const customFilenameInput = page.getByLabel("Custom Filename (Optional)");
+    await expect(customFilenameInput).toBeVisible();
+    await customFilenameInput.fill("MyAwesomeVideo.%(ext)s");
+
+    // Intercept POST to verify payload and return mocked record with custom filename
+    let interceptedRequestPayload: any = null;
+    await page.route("/api/downloads", async (route) => {
+      if (route.request().method() === "POST") {
+        interceptedRequestPayload = route.request().postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            record: {
+              id: "test-id",
+              createdAt: new Date().toISOString(),
+              url: "https://example.com/watch?v=custom-filename",
+              mode: "video",
+              includePlaylist: false,
+              resolution: "best",
+              customFilename: "MyAwesomeVideo.%(ext)s",
+              status: "completed",
+              files: ["MyAwesomeVideo.mp4"],
+              logTail: "done",
+            },
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    const submitBtn = page.getByRole("button", { name: "Download and Archive" });
+    await submitBtn.click();
+
+    // Verify request payload
+    expect(interceptedRequestPayload).not.toBeNull();
+    expect(interceptedRequestPayload.customFilename).toBe("MyAwesomeVideo.%(ext)s");
+
+    // Verify history rendering includes the custom filename badge
+    const historyList = page.getByTestId("history-list");
+    await expect(historyList).toBeVisible();
+
+    const historyItems = historyList.locator("li.history-item");
+    await expect(historyItems).toHaveCount(1);
+
+    const customBadge = historyItems.first().locator(".custom-filename-badge");
+    await expect(customBadge).toBeVisible();
+    await expect(customBadge).toHaveText("Custom Name");
+  });
+});

--- a/website/tests/ytdlp.test.ts
+++ b/website/tests/ytdlp.test.ts
@@ -70,6 +70,38 @@ describe("buildYtDlpArgs", () => {
     expect(args).toContain("--format");
     expect(args).toContain("bestvideo[height<=720]+bestaudio/best[height<=720]");
   });
+
+  it("builds args with custom filename", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        customFilename: "MyCustomName.%(ext)s",
+      },
+      paths,
+    );
+
+    const outputIndex = args.indexOf("--output");
+    expect(args[outputIndex + 1]).toBe("MyCustomName.%(ext)s");
+  });
+
+  it("sanitizes custom filename to prevent directory traversal", () => {
+    const paths = getDataPaths("/tmp/archive");
+    const args = buildYtDlpArgs(
+      {
+        url: "https://example.com/watch?v=video",
+        mode: "video",
+        includePlaylist: false,
+        customFilename: "../../etc/passwd",
+      },
+      paths,
+    );
+
+    const outputIndex = args.indexOf("--output");
+    expect(args[outputIndex + 1]).toBe("etc/passwd");
+  });
 });
 
 describe("downloaded file parsing", () => {


### PR DESCRIPTION
Implements the custom output filename feature requested in the `docs/requirements.md` and created/closed in the `docs/backlog/` directory.

- Adds a "Custom Filename (Optional)" field to the frontend.
- Sends the custom filename to the backend where it is validated and sanitized against directory traversal.
- Uses the custom filename as the `--output` parameter for `yt-dlp`.
- Shows a "Custom Name" badge in the history UI.
- Adds full unit tests and a Playwright E2E test.

---
*PR created automatically by Jules for task [3916478320180152491](https://jules.google.com/task/3916478320180152491) started by @jjgroenendijk*