### PR TITLE
Merge main into dependabot PR #267

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |


### PR DESCRIPTION
Merged `main` into the dependabot PR branch `dependabot/github_actions/docker/metadata-action-6` to force a workflow update and resolve the automatic merge block. Tested that python and node tests pass successfully.

---
*PR created automatically by Jules for task [6073175300846900876](https://jules.google.com/task/6073175300846900876) started by @jjgroenendijk*