### PR TITLE
[codex] Harden Jules autonomy prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The automation will:
 2. Resolve this repository as a Jules source.
 3. Start a Jules session immediately when the repo has no active Jules work.
 4. Queue the issue automatically when another Jules session for this repo is still running.
-5. Comment back with the session ID once the issue starts.
+5. Wrap the issue body with autonomy instructions so Jules keeps working through routine implementation and verification steps without pausing for confirmation.
+6. Comment back with the session ID once the issue starts.
 
 Issue-triggered Jules entry stays owner-only even if you configure extra trusted PR actors.
 

--- a/docs/backlog/closed/008_jules_autonomy_prompt.md
+++ b/docs/backlog/closed/008_jules_autonomy_prompt.md
@@ -1,0 +1,19 @@
+# 008 Jules Autonomy Prompt
+
+## What
+Make every new Jules session start with explicit autonomy rules so it finishes work without asking the user for routine confirmation or permission to continue.
+
+## Why
+Jules is stopping mid-task to ask whether it should proceed with obvious next steps like code quality checks. That stalls issue-driven automation and defeats the point of the repository's autonomous workflow.
+
+## Progress
+- [x] Open backlog item for Jules autonomy prompt hardening.
+- [x] Wrap new session prompts with explicit autonomy instructions.
+- [x] Disable plan approval explicitly in the session payload.
+- [x] Add regression tests for the generated prompt and session payload.
+- [x] Update requirements and README with the new autonomy expectation.
+- [x] Verify locally and move this item to `docs/backlog/closed/`.
+
+## Verification
+- `uv run pytest`
+- `uv run ruff check`

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -19,6 +19,7 @@ This repository integrates **Google Jules** via its REST API and hosts a web int
 - **Single Active Session:** Only one non-terminal Jules session may be active for this repository at a time.
 - **Queued Retry:** When a new issue arrives while Jules is busy, the issue is queued and retried automatically until it starts.
 - **Owner-Gated Issue Entry:** Public issue/comment events only start or steer Jules when they come from the repository owner.
+- **Autonomous Session Prompting:** New Jules sessions must be instructed to continue autonomously without asking for routine plan approval or user feedback for normal implementation and verification steps.
 - **Trusted PR Automation:** Privileged PR follow-up automation only acts on trusted same-repo PRs.
 - **Configurable Trusted Actors:** The repository owner is trusted by default, and optional extra logins may be provided through `JULES_TRUSTED_ACTORS`.
 - **Scheduled Recovery:** Recurring autonomous runs must reuse the same issue-backed flow instead of relying on Jules-native scheduling.

--- a/jules.py
+++ b/jules.py
@@ -15,6 +15,17 @@ import requests
 JULES_API_BASE = "https://jules.googleapis.com/v1alpha"
 SESSION_ID_PATTERN = re.compile(r"\*\*Session ID:\*\* `(sessions/[^`]+)`")
 QUEUE_MARKER = "<!-- jules-queue -->"
+AUTONOMY_PROMPT_HEADER = """You are running through this repository's autonomous GitHub issue bridge.
+
+Execution rules:
+- Follow the repository instructions in `AGENTS.md`.
+- Work autonomously from start to finish.
+- Never ask the user for plan approval, permission to continue, or routine feedback.
+- Do not stop to ask whether you should run normal quality checks, tests, formatting, verification, or documentation updates. Do them when they are relevant.
+- If more than one reasonable option exists, choose the safest option that keeps progress moving and explain the choice in your summary instead of pausing.
+- Only ask for input when blocked by missing credentials, an external dependency you cannot access, or irreconcilable conflicting requirements.
+- Before finishing, run the relevant verification for the work you changed.
+"""
 BUSY_SESSION_STATES = {
     "QUEUED",
     "PLANNING",
@@ -28,6 +39,19 @@ BUSY_SESSION_STATES = {
 def is_session_busy(session):
     """Return True when a session still occupies the repo's only active slot."""
     return str(session.get("state") or "").upper() in BUSY_SESSION_STATES
+
+
+def build_session_prompt(title, body):
+    """Wrap the issue body with autonomy instructions for new Jules sessions."""
+    issue_title = (title or "").strip() or "Untitled issue"
+    issue_body = (body or "").strip() or "No additional task details were provided."
+
+    return (
+        f"{AUTONOMY_PROMPT_HEADER}\n"
+        f"Issue title: {issue_title}\n\n"
+        "Issue details:\n"
+        f"{issue_body}"
+    )
 
 
 class JulesClient:
@@ -96,6 +120,7 @@ class JulesClient:
                 },
             },
             "automationMode": "AUTO_CREATE_PR",
+            "requirePlanApproval": False,
             "title": title,
         }
 
@@ -373,7 +398,11 @@ def start_issue_session(client, issue_number, title, body, owner, repo_name, ful
             return 0
 
         print(f"Creating Session with Source: {source_name}")
-        session = client.create_session(source_name, prompt=body or "", title=title)
+        session = client.create_session(
+            source_name,
+            prompt=build_session_prompt(title, body),
+            title=title,
+        )
         session_id = session.get("name")
 
         print(f"Session Created: {session_id}")

--- a/tests/test_jules_bridge.py
+++ b/tests/test_jules_bridge.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -84,3 +84,32 @@ def test_find_next_pending_issue_skips_issues_with_existing_sessions(
         "comments": [],
     }
     mock_list_open_issues.assert_called_once_with("owner/repo")
+
+
+@patch("jules.post_issue_comment")
+def test_start_issue_session_wraps_issue_body_with_autonomy_prompt(
+    mock_post_issue_comment,
+):
+    client = MagicMock()
+    client.find_source_for_repo.return_value = "sources/github/owner/repo"
+    client.find_busy_session_for_source.return_value = None
+    client.create_session.return_value = {"name": "sessions/123"}
+
+    exit_code = jules.start_issue_session(
+        client,
+        7,
+        "Embed Subtitles",
+        "Add the checkbox and yt-dlp flags.",
+        "owner",
+        "repo",
+        "owner/repo",
+    )
+
+    assert exit_code == 0
+    client.create_session.assert_called_once()
+    args, kwargs = client.create_session.call_args
+    assert args[0] == "sources/github/owner/repo"
+    assert kwargs["title"] == "Embed Subtitles"
+    assert "Never ask the user for plan approval" in kwargs["prompt"]
+    assert "Issue title: Embed Subtitles" in kwargs["prompt"]
+    assert "Add the checkbox and yt-dlp flags." in kwargs["prompt"]

--- a/tests/test_jules_session.py
+++ b/tests/test_jules_session.py
@@ -6,7 +6,7 @@ import os
 # Add root to sys.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from jules import JulesClient, JULES_API_BASE
+from jules import JulesClient, JULES_API_BASE, build_session_prompt
 
 
 class TestJulesSession(unittest.TestCase):
@@ -46,6 +46,7 @@ class TestJulesSession(unittest.TestCase):
                 "githubRepoContext": {"startingBranch": "main"},
             },
             "automationMode": "AUTO_CREATE_PR",
+            "requirePlanApproval": False,
             "title": "Test Title",
         }
 
@@ -62,6 +63,23 @@ class TestJulesSession(unittest.TestCase):
         mock_get.assert_called_with(expected_get_url, headers=self.client.headers)
 
         self.assertEqual(session, {"name": "sessions/123"})
+
+    def test_build_session_prompt_adds_autonomy_rules_and_issue_details(self):
+        prompt = build_session_prompt(
+            "Embed Subtitles",
+            "Add a checkbox and wire yt-dlp embed subtitle flags.",
+        )
+
+        self.assertIn("Work autonomously from start to finish.", prompt)
+        self.assertIn("Never ask the user for plan approval", prompt)
+        self.assertIn("Issue title: Embed Subtitles", prompt)
+        self.assertIn("Add a checkbox and wire yt-dlp embed subtitle flags.", prompt)
+
+    def test_build_session_prompt_handles_missing_body(self):
+        prompt = build_session_prompt("Untitled", "")
+
+        self.assertIn("Issue title: Untitled", prompt)
+        self.assertIn("No additional task details were provided.", prompt)
 
     @patch("requests.post")
     def test_send_message(self, mock_post):


### PR DESCRIPTION
## Summary
- add a bridge-level autonomy prompt wrapper for new Jules sessions
- disable plan approval explicitly in the session payload and document the behavior
- add regression tests covering the generated prompt and session launch flow

## Why
Jules was pausing to ask for routine permission before finishing obvious next steps like quality checks. The issue bridge should bias toward autonomous completion for normal implementation and verification work.

## Validation
- `uv run pytest`
- `uv run ruff check`