### PR TITLE
Update sendemail-validate.sample with checkpatch.pl logic

### DIFF
--- a/patches/sendemail-validate.sample
+++ b/patches/sendemail-validate.sample
@@ -40,9 +40,11 @@ validate_patch () {
 	file="$1"
 	# Ensure that the patch applies without conflicts.
 	git am -3 "$file" || return
-	# TODO: Replace with appropriate checks for this patch
-	# (e.g. checkpatch.pl).
-	true
+	# Run checkpatch.pl if it's available.
+	if command -v checkpatch.pl >/dev/null 2>&1
+	then
+		checkpatch.pl "$file" || return
+	fi
 }
 
 validate_series () {


### PR DESCRIPTION
This PR replaces the generic TODO comment in `patches/sendemail-validate.sample` with a practical check block. It uses `command -v` to look for `checkpatch.pl` in the environment path and, if found, runs it against the patch file. This provides a functional, out-of-the-box checkpatch behavior while remaining a generic sample script since it safely skips if the tool doesn't exist.

---
*PR created automatically by Jules for task [14119143497277386201](https://jules.google.com/task/14119143497277386201) started by @jjgroenendijk*