### PR TITLE
feat: add clear history feature

### DIFF
--- a/docs/backlog/closed/clear-history.md
+++ b/docs/backlog/closed/clear-history.md
@@ -1,0 +1,13 @@
+# Clear History Feature
+
+**Goal**: Allow users to clear non-active jobs from their SpotiFLAC history to keep the UI tidy.
+
+**Requirements**:
+1. A new backend endpoint `DELETE /api/history/clear` that filters the `history.json` file.
+   - It must remove any jobs with a status of "Completed", "Failed", or "Cancelled".
+   - It must retain any jobs with a status of "Queued" or "Running".
+2. A new "Clear history" button in the frontend job list section.
+   - Clicking it calls the new backend endpoint.
+   - The UI should refresh the job list afterward.
+3. Tests for backend endpoint.
+4. Playwright tests for frontend feature.

--- a/server.py
+++ b/server.py
@@ -188,6 +188,26 @@ async def get_job_log(job_id: str):
         logger.error(f"Error reading log file for {job_id}: {e}")
         raise HTTPException(status_code=500, detail="Error reading log")
 
+
+@app.delete("/api/history/clear")
+async def clear_history():
+    history = []
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        # Keep only active jobs
+        filtered_history = [
+            job for job in history
+            if job.get("status") in ["Queued", "Running"]
+        ]
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(filtered_history, f, indent=2)
+
+    return {"status": "success", "cleared": len(history) - len(filtered_history)}
+
 @app.delete("/api/jobs/{job_id}")
 async def cancel_job(job_id: str):
     history = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
@@ -85,3 +86,54 @@ def test_get_job_log_not_found(tmp_path, monkeypatch):
 
     response = client.get("/api/jobs/nonexistent-job/log")
     assert response.status_code == 404
+
+@patch('server.run_spotiflac')
+def test_clear_history(mock_run):
+    # Create an initial job (mock makes it complete successfully, but background task means it might be queued initially)
+    # However, for tests, we can directly manipulate the test history file or create a job and let it run,
+    # then clear history.
+
+    # Create two jobs
+    response1 = client.post("/api/jobs", json={"url": "https://open.spotify.com/track/123"})
+    job1_id = response1.json()["id"]
+
+    response2 = client.post("/api/jobs", json={"url": "https://open.spotify.com/track/456"})
+    job2_id = response2.json()["id"]
+
+    # One job we'll cancel so it's "Cancelled"
+    client.delete(f"/api/jobs/{job1_id}")
+
+    # Wait for the other job to potentially be running or queued, let's inject a "Completed" status
+    # for testing purposes into the history file directly to be sure it gets cleared.
+
+    with open(HISTORY_FILE, "r") as f:
+        history = json.load(f)
+
+    for job in history:
+        if job["id"] == job2_id:
+            job["status"] = "Completed"
+
+    history.append({
+        "id": "running-job-id",
+        "url": "https://open.spotify.com/track/789",
+        "status": "Running",
+        "created_at": "2023-01-01T00:00:00Z"
+    })
+
+    with open(HISTORY_FILE, "w") as f:
+        json.dump(history, f, indent=2)
+
+    # Call clear history
+    response = client.delete("/api/history/clear")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["cleared"] >= 2 # Cancelled and Completed
+
+    # Verify history
+    response = client.get("/api/jobs")
+    jobs = response.json()
+
+    # Only the "Running" job should remain
+    assert len(jobs) == 1
+    assert jobs[0]["id"] == "running-job-id"
+    assert jobs[0]["status"] == "Running"

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -101,8 +101,9 @@ export function renderApp(root) {
       </section>
 
       <section class="jobs" aria-label="Recent jobs">
-        <div class="section-heading">
+        <div class="section-heading section-heading-with-action">
           <h2>Recent jobs</h2>
+          <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
         </div>
         <div class="job-list" id="job-list">
           <!-- Jobs will be loaded here -->
@@ -228,6 +229,27 @@ export function renderApp(root) {
     }
   });
 
+
+  const clearHistoryBtn = root.querySelector("#clear-history-btn");
+  if (clearHistoryBtn) {
+    clearHistoryBtn.addEventListener("click", async () => {
+      clearHistoryBtn.disabled = true;
+      clearHistoryBtn.textContent = "Clearing...";
+      try {
+        const response = await fetch("/api/history/clear", { method: "DELETE" });
+        if (response.ok) {
+          fetchJobs();
+        }
+      } catch (err) {
+        console.error("Failed to clear history", err);
+      } finally {
+        clearHistoryBtn.disabled = false;
+        clearHistoryBtn.textContent = "Clear history";
+      }
+    });
+  }
+
   // Return cleanup function
+
   return () => clearInterval(pollInterval);
 }

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -393,3 +393,31 @@ button:active {
   word-break: break-all;
   border: 1px solid rgba(31, 122, 77, 0.1);
 }
+
+.clear-history-btn {
+  background: rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  color: #17201b;
+  font-weight: 500;
+}
+
+.clear-history-btn:hover {
+  background: rgba(255, 255, 255, 0.5);
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.clear-history-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.section-heading-with-action {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -150,3 +150,62 @@ test('can view job logs', async ({ page }) => {
   // Verify log container is hidden again
   await expect(logsContainer).toBeHidden();
 });
+
+test("can clear job history", async ({ page }) => {
+  // Mock API route for jobs to provide mixed jobs
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "1",
+            url: "https://open.spotify.com/track/1",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 1,
+            error_log: null
+          },
+          {
+            id: "2",
+            url: "https://open.spotify.com/track/2",
+            status: "Running",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  let clearHistoryCalled = false;
+  await page.route("/api/history/clear", async (route) => {
+    if (route.request().method() === "DELETE") {
+      clearHistoryCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "success", cleared: 1 })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  const clearBtn = page.getByRole("button", { name: "Clear history" });
+  await expect(clearBtn).toBeVisible();
+
+  await clearBtn.click();
+
+  // Playwright executes the mock fetch almost instantly, so we might miss the 'Clearing...' text.
+  // We can just verify it returned to 'Clear history' and the mock was called.
+  await expect(page.getByRole("button", { name: "Clear history" })).toBeVisible();
+
+  expect(clearHistoryCalled).toBe(true);
+});


### PR DESCRIPTION
Implemented the autonomous task of adding a "Clear history" feature, as defined and tracked through the backlog workflow. Users can now click a button to filter out completed, failed, or cancelled jobs, leaving only active tasks on the page.

---
*PR created automatically by Jules for task [15897748287853475621](https://jules.google.com/task/15897748287853475621) started by @jjgroenendijk*