### PR TITLE
feat(ui): add retry button for failed and cancelled jobs

### DIFF
--- a/docs/backlog/closed/retry-jobs.md
+++ b/docs/backlog/closed/retry-jobs.md
@@ -1,0 +1,12 @@
+# Retry Failed/Cancelled Jobs
+
+## Requirement
+Currently, if a job fails or is cancelled, there is no easy way for the user to try again without copying the URL and manually pasting it back into the queue form.
+To improve the user experience, we should add a "Retry" button to jobs that are in a "Failed" or "Cancelled" state.
+
+## Tasks
+- Add a "Retry" button inside the job card actions when the job status is "Failed" or "Cancelled".
+- Style the "Retry" button using the existing Apple Liquid Glass aesthetic.
+- Clicking the "Retry" button should issue a POST request to `/api/jobs` with the URL from the failed/cancelled job to queue it again.
+- The job list should visually update to reflect the newly queued job immediately.
+- Add appropriate Playwright tests to ensure the "Retry" button appears for the correct job states and functions as expected.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -36,7 +36,9 @@ function renderJob(job) {
   const errorHtml = job.error_log ? `<pre class="job-error">${escapeHtml(job.error_log)}</pre>` : "";
   const filesText = job.files === 1 ? "1 file" : `${job.files} files`;
   const canCancel = job.status === "Queued" || job.status === "Running";
+  const canRetry = job.status === "Failed" || job.status === "Cancelled";
   const cancelBtnHtml = canCancel ? `<button type="button" class="cancel-job-btn" data-job-id="${escapeHtml(job.id)}">Cancel</button>` : "";
+  const retryBtnHtml = canRetry ? `<button type="button" class="retry-job-btn" data-job-url="${escapeHtml(job.url)}">Retry</button>` : "";
   const viewLogsBtnHtml = `<button type="button" class="view-logs-btn" data-job-id="${escapeHtml(job.id)}">View Logs</button>`;
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
@@ -53,6 +55,7 @@ function renderJob(job) {
         <div class="job-actions">
           ${viewLogsBtnHtml}
           ${cancelBtnHtml}
+          ${retryBtnHtml}
         </div>
       </div>
       ${errorHtml}
@@ -275,6 +278,32 @@ export function renderApp(root) {
         console.error("Failed to cancel job", err);
         event.target.disabled = false;
         event.target.textContent = "Cancel";
+      }
+    }
+
+    if (event.target.classList.contains("retry-job-btn")) {
+      const jobUrl = event.target.dataset.jobUrl;
+      if (!jobUrl) return;
+
+      event.target.disabled = true;
+      event.target.textContent = "Retrying...";
+
+      try {
+        const response = await fetch("/api/jobs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url: jobUrl })
+        });
+        if (response.ok) {
+          fetchJobs();
+        } else {
+          event.target.disabled = false;
+          event.target.textContent = "Retry";
+        }
+      } catch (err) {
+        console.error("Failed to retry job", err);
+        event.target.disabled = false;
+        event.target.textContent = "Retry";
       }
     }
   });

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -305,7 +305,8 @@ button:active {
   color: #10b981;
 }
 
-.cancel-job-btn {
+.cancel-job-btn,
+.retry-job-btn {
   background: rgba(255, 255, 255, 0.5);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
@@ -320,13 +321,15 @@ button:active {
   box-shadow: 0 2px 8px 0 rgba(31, 38, 135, 0.05);
 }
 
-.cancel-job-btn:hover:not(:disabled) {
+.cancel-job-btn:hover:not(:disabled),
+.retry-job-btn:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.8);
   color: var(--text);
   border-color: rgba(255, 255, 255, 0.8);
 }
 
-.cancel-job-btn:disabled {
+.cancel-job-btn:disabled,
+.retry-job-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   transform: none;

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -62,6 +62,52 @@ test("validates supported Spotify URLs and queues job", async ({ page }) => {
 });
 
 
+test("shows retry button for failed job and handles click", async ({ page }) => {
+  // Mock API route for jobs to provide a failed job
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "126",
+            url: "https://open.spotify.com/track/789",
+            status: "Failed",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: "Something went wrong"
+          }
+        ]),
+      });
+    } else if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "127",
+          url: "https://open.spotify.com/track/789",
+          status: "Queued",
+          created_at: new Date().toISOString(),
+          files: 0,
+          error_log: null
+        })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  const retryBtn = page.getByRole("button", { name: "Retry" });
+  await expect(retryBtn).toBeVisible();
+
+  await retryBtn.click();
+
+  await expect(page.getByRole("button", { name: "Retrying..." })).toBeVisible();
+});
+
 test("shows cancel button for queued job and handles click", async ({ page }) => {
   // First we need to override the initial GET mock to show a queued job
   await page.route("/api/jobs", async (route) => {


### PR DESCRIPTION
This commit implements the retry-jobs feature, enabling a quick "Retry" action for SpotiFLAC web UI jobs that fail or are cancelled. It updates `app.js` with the logic, adds styles to `styles.css`, updates the test coverage in `web-ui.spec.js`, and tracks the requirement in `docs/backlog`.

---
*PR created automatically by Jules for task [12677498741659949521](https://jules.google.com/task/12677498741659949521) started by @jjgroenendijk*