### PR TITLE
feat(spotiflac): Add backend endpoint and UI button to download job as ZIP archive

### DIFF
--- a/docs/backlog/closed/download-job-as-zip.md
+++ b/docs/backlog/closed/download-job-as-zip.md
@@ -1,0 +1,11 @@
+# Download Job as ZIP Archive
+
+## Requirement
+Users self-hosting the app may want to easily download the completed tracks from a specific job directly through their browser, rather than having to access the `/data` volume over the network (e.g., via SMB/NFS or Docker volume mounts).
+
+Adding a backend endpoint to compress and stream a job's output directory as a ZIP archive, along with a UI button to trigger the download, will significantly improve the user experience for homelab users.
+
+## Tasks
+1. Add a backend endpoint `GET /api/jobs/{job_id}/download` that creates a ZIP archive of the job's output directory and returns it as a `FileResponse` or streaming response.
+2. Update the frontend job card UI to display a "Download ZIP" button for jobs in the "Completed" state.
+3. Write/update unit tests for the backend endpoint and Playwright tests for the frontend UI.

--- a/server.py
+++ b/server.py
@@ -255,7 +255,48 @@ async def get_job_progress(job_id: str):
         return None
 
 
+
+@app.get("/api/jobs/{job_id}/download")
+def download_job(job_id: str, background_tasks: BackgroundTasks):
+    import re
+    import shutil
+    import tempfile
+    import os
+
+    if not re.match(r"^[a-zA-Z0-9-]+$", job_id):
+        raise HTTPException(status_code=400, detail="Invalid job ID format")
+
+    job_dir = (DATA_DIR / job_id).resolve()
+
+    if not job_dir.is_relative_to(DATA_DIR.resolve()):
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    if not job_dir.exists() or not job_dir.is_dir():
+        raise HTTPException(status_code=404, detail="Job directory not found")
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+    temp_file.close()
+
+    base_name = temp_file.name[:-4]
+    try:
+        shutil.make_archive(base_name, 'zip', job_dir)
+    except Exception:
+        if os.path.exists(temp_file.name):
+            os.unlink(temp_file.name)
+        raise
+
+    zip_path = temp_file.name
+
+    background_tasks.add_task(os.unlink, zip_path)
+
+    return FileResponse(
+        path=zip_path,
+        media_type="application/zip",
+        filename=f"SpotiFLAC-{job_id}.zip"
+    )
+
 @app.delete("/api/history/clear")
+
 async def clear_history():
     history = []
     async with history_lock:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -188,3 +188,33 @@ def test_clear_history(mock_run):
     assert len(jobs) == 1
     assert jobs[0]["id"] == "running-job-id"
     assert jobs[0]["status"] == "Running"
+
+def test_download_job_zip(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    monkeypatch.setattr("server.DATA_DIR", data_dir)
+
+    job_id = "test-download-job"
+    job_dir = data_dir / job_id
+    job_dir.mkdir()
+
+    (job_dir / "track.flac").write_text("dummy flac content")
+
+    response = client.get(f"/api/jobs/{job_id}/download")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+
+    # We could also check if the zip file actually unzips properly, but checking response headers is sufficient here.
+
+def test_download_job_zip_invalid_id():
+    response = client.get("/api/jobs/invalid..id/download")
+    assert response.status_code == 400
+
+def test_download_job_zip_not_found(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr("server.DATA_DIR", data_dir)
+
+    response = client.get("/api/jobs/nonexistent-job/download")
+    assert response.status_code == 404

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -41,6 +41,7 @@ function renderJob(job) {
   const retryBtnHtml = canRetry ? `<button type="button" class="retry-job-btn" data-job-url="${escapeHtml(job.url)}">Retry</button>` : "";
   const viewLogsBtnHtml = `<button type="button" class="view-logs-btn" data-job-id="${escapeHtml(job.id)}">View Logs</button>`;
   const viewFilesBtnHtml = job.status === "Completed" ? `<button type="button" class="view-files-btn" data-job-id="${escapeHtml(job.id)}">View Files</button>` : "";
+  const downloadZipBtnHtml = job.status === "Completed" ? `<a href="/api/jobs/${escapeHtml(job.id)}/download" download class="download-zip-btn view-files-btn">Download ZIP</a>` : "";
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
 
@@ -56,6 +57,7 @@ function renderJob(job) {
         <div class="job-actions">
           ${viewLogsBtnHtml}
           ${viewFilesBtnHtml}
+          ${downloadZipBtnHtml}
           ${cancelBtnHtml}
           ${retryBtnHtml}
         </div>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -482,3 +482,12 @@ button:active {
 .job-files-list li {
   margin-bottom: 4px;
 }
+
+.download-zip-btn {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  line-height: normal;
+}

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -321,3 +321,20 @@ test("displays visual progress bar for running jobs", async ({ page }) => {
   // We check style="width: 50%;" inline style
   await expect(progressBarFill).toHaveAttribute("style", "width: 50%;");
 });
+
+test('displays Download ZIP link for completed jobs', async ({ page }) => {
+  await page.goto('/');
+
+  // Wait for the job card with ID 123 (which is mocked as "Completed" in beforeEach)
+  const jobCard = page.locator('.job-card').filter({ hasText: '1ATL5GLyefJaxhQzSPVrLX' });
+  await expect(jobCard).toBeVisible();
+
+  // Find the Download ZIP link
+  const downloadLink = jobCard.locator('.download-zip-btn');
+  await expect(downloadLink).toBeVisible();
+  await expect(downloadLink).toHaveText('Download ZIP');
+
+  // Verify the href attribute
+  await expect(downloadLink).toHaveAttribute('href', '/api/jobs/123/download');
+  await expect(downloadLink).toHaveAttribute('download', '');
+});


### PR DESCRIPTION
Adds the ability to download a completed SpotiFLAC job's output directory as a ZIP archive directly from the web UI.

Closes `docs/backlog/open/download-job-as-zip.md`

---
*PR created automatically by Jules for task [14050416461102587272](https://jules.google.com/task/14050416461102587272) started by @jjgroenendijk*