### PR TITLE
feat: implement job deletion and file cleanup

### DIFF
--- a/docs/backlog/closed/delete-job-cleanup.md
+++ b/docs/backlog/closed/delete-job-cleanup.md
@@ -1,0 +1,4 @@
+# Requirement: Job Deletion and File Cleanup
+As a homelab user, I want a way to delete a job to free up disk space.
+- The clear history button should also delete the files and logs of the cleared jobs.
+- Individual non-active jobs should have a "Delete" button that removes them from history and deletes their files and logs from disk.

--- a/docs/backlog/open/download-all-btn.md
+++ b/docs/backlog/open/download-all-btn.md
@@ -1,0 +1,2 @@
+# Requirement: Global Download All Button
+- As a user, I want a way to bulk download all jobs (like a global "Download all completed" zip button) or clear history.

--- a/server.py
+++ b/server.py
@@ -319,48 +319,67 @@ def download_job(job_id: str, background_tasks: BackgroundTasks):
         filename=f"SpotiFLAC-{job_id}.zip"
     )
 
-@app.delete("/api/history/clear")
+def _delete_job_files(job_id: str):
+    import shutil
+    job_dir = DATA_DIR / job_id
+    if job_dir.exists() and job_dir.is_dir():
+        shutil.rmtree(job_dir, ignore_errors=True)
 
+@app.delete("/api/history/clear")
 async def clear_history():
     history = []
+    cleared_jobs = []
     async with history_lock:
         if HISTORY_FILE.exists():
             with open(HISTORY_FILE, "r") as f:
                 history = json.load(f)
 
-        # Keep only active jobs
-        filtered_history = [
-            job for job in history
-            if job.get("status") in ["Queued", "Running"]
-        ]
+        filtered_history = []
+        for job in history:
+            if job.get("status") in ["Queued", "Running"]:
+                filtered_history.append(job)
+            else:
+                cleared_jobs.append(job["id"])
 
         with open(HISTORY_FILE, "w") as f:
             json.dump(filtered_history, f, indent=2)
 
-    return {"status": "success", "cleared": len(history) - len(filtered_history)}
+    for job_id in cleared_jobs:
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        await asyncio.to_thread(_delete_job_files, job_id)
+
+    return {"status": "success", "cleared": len(cleared_jobs)}
 
 @app.delete("/api/jobs/{job_id}")
 async def cancel_job(job_id: str):
     history = []
+    delete_job_files_flag = False
     async with history_lock:
         if HISTORY_FILE.exists():
             with open(HISTORY_FILE, "r") as f:
                 history = json.load(f)
 
         job_found = False
+        new_history = []
 
         for job in history:
             if job["id"] == job_id:
                 job_found = True
                 if job["status"] in ["Queued", "Running"]:
                     job["status"] = "Cancelled"
-                break
+                    new_history.append(job)
+                else:
+                    # Actually delete it from history
+                    delete_job_files_flag = True
+            else:
+                new_history.append(job)
 
         if not job_found:
             raise HTTPException(status_code=404, detail="Job not found")
 
         with open(HISTORY_FILE, "w") as f:
-            json.dump(history, f, indent=2)
+            json.dump(new_history, f, indent=2)
 
     if job_id in running_processes:
         process = running_processes[job_id]
@@ -368,6 +387,11 @@ async def cancel_job(job_id: str):
             process.terminate()
         except ProcessLookupError:
             pass
+
+    if delete_job_files_flag:
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        await asyncio.to_thread(_delete_job_files, job_id)
 
     return {"status": "success"}
 

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -37,8 +37,10 @@ function renderJob(job) {
   const filesText = job.files === 1 ? "1 file" : `${job.files} files`;
   const canCancel = job.status === "Queued" || job.status === "Running";
   const canRetry = job.status === "Failed" || job.status === "Cancelled";
+  const canDelete = job.status === "Completed" || job.status === "Failed" || job.status === "Cancelled";
   const cancelBtnHtml = canCancel ? `<button type="button" class="cancel-job-btn" data-job-id="${escapeHtml(job.id)}">Cancel</button>` : "";
   const retryBtnHtml = canRetry ? `<button type="button" class="retry-job-btn" data-job-url="${escapeHtml(job.url)}">Retry</button>` : "";
+  const deleteBtnHtml = canDelete ? `<button type="button" class="delete-job-btn" data-job-id="${escapeHtml(job.id)}">Delete</button>` : "";
   const viewLogsBtnHtml = `<button type="button" class="view-logs-btn" data-job-id="${escapeHtml(job.id)}">View Logs</button>`;
   const viewFilesBtnHtml = job.status === "Completed" ? `<button type="button" class="view-files-btn" data-job-id="${escapeHtml(job.id)}">View Files</button>` : "";
   const downloadZipBtnHtml = job.status === "Completed" ? `<a href="/api/jobs/${escapeHtml(job.id)}/download" download class="download-zip-btn view-files-btn">Download ZIP</a>` : "";
@@ -60,6 +62,7 @@ function renderJob(job) {
           ${downloadZipBtnHtml}
           ${cancelBtnHtml}
           ${retryBtnHtml}
+          ${deleteBtnHtml}
         </div>
       </div>
       ${errorHtml}
@@ -389,6 +392,30 @@ export function renderApp(root) {
         console.error("Failed to retry job", err);
         event.target.disabled = false;
         event.target.textContent = "Retry";
+      }
+    }
+
+    if (event.target.classList.contains("delete-job-btn")) {
+      const jobId = event.target.dataset.jobId;
+      if (!jobId) return;
+
+      event.target.disabled = true;
+      event.target.textContent = "Deleting...";
+
+      try {
+        const response = await fetch(`/api/jobs/${jobId}`, {
+          method: "DELETE"
+        });
+        if (response.ok) {
+          fetchJobs();
+        } else {
+          event.target.disabled = false;
+          event.target.textContent = "Delete";
+        }
+      } catch (err) {
+        console.error("Failed to delete job", err);
+        event.target.disabled = false;
+        event.target.textContent = "Delete";
       }
     }
   });

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -435,7 +435,8 @@ button:active {
 }
 
 .cancel-job-btn,
-.retry-job-btn {
+.retry-job-btn,
+.delete-job-btn {
   background: var(--glass-bg);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
@@ -451,14 +452,16 @@ button:active {
 }
 
 .cancel-job-btn:hover:not(:disabled),
-.retry-job-btn:hover:not(:disabled) {
+.retry-job-btn:hover:not(:disabled),
+.delete-job-btn:hover:not(:disabled) {
   background: var(--glass-bg-hover);
   color: var(--text-primary);
   border-color: var(--glass-border);
 }
 
 .cancel-job-btn:disabled,
-.retry-job-btn:disabled {
+.retry-job-btn:disabled,
+.delete-job-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   transform: none;

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -110,6 +110,56 @@ test("shows retry button for failed job and handles click", async ({ page }) => 
   await expect(page.getByRole("button", { name: "Retrying..." })).toBeVisible();
 });
 
+test("can delete a job", async ({ page }) => {
+  // Mock API route for jobs to provide a completed job
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "job-to-delete",
+            url: "https://open.spotify.com/track/delete-me",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 1,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  let deleteJobCalled = false;
+  await page.route("**/api/jobs/job-to-delete", async (route) => {
+    if (route.request().method() === "DELETE") {
+      deleteJobCalled = true;
+      setTimeout(async () => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ status: "success" })
+        });
+      }, 500);
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  const deleteBtn = page.getByRole("button", { name: "Delete" });
+  await expect(deleteBtn).toBeVisible();
+
+  await deleteBtn.click();
+  await expect(page.getByRole("button", { name: "Deleting..." })).toBeVisible();
+
+  expect(deleteJobCalled).toBe(true);
+});
+
 test("shows cancel button for queued job and handles click", async ({ page }) => {
   // First we need to override the initial GET mock to show a queued job
   await page.route("/api/jobs", async (route) => {


### PR DESCRIPTION
This implements the "Job Deletion and File Cleanup" backlog requirement. It ensures that when users clear history or manually delete an inactive job (Completed, Failed, Cancelled) from the UI, the backend will properly perform cleanup logic to remove the downloaded files and log files from the server, freeing up disk space. It adds the "Delete" button for inactive jobs alongside "Retry", fully integrated with tests.

---
*PR created automatically by Jules for task [10471581479789293093](https://jules.google.com/task/10471581479789293093) started by @jjgroenendijk*