### PR TITLE
feat(ui): Add job status filter dropdown

### DIFF
--- a/docs/backlog/closed/015_filter_jobs_by_status.md
+++ b/docs/backlog/closed/015_filter_jobs_by_status.md
@@ -1,0 +1,10 @@
+# Filter Jobs by Status
+
+## Description
+Add a dropdown filter to the SpotiFLAC Web UI's job list. This feature allows users to filter jobs based on their current status (e.g., All, Queued, Running, Completed, Failed, Cancelled) to make it easier to find specific jobs, especially when the history is long.
+
+## Tasks
+- Add a dropdown (`<select>`) next to the "Clear history" button in the UI.
+- Update `app.js` to handle the dropdown state and filter the jobs list based on the selected value before rendering.
+- Add CSS styling in `styles.css` to match the "Apple Liquid Glass" style guide.
+- Add test coverage in `web-ui.spec.js` to ensure the filtering logic works correctly.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -129,7 +129,15 @@ export function renderApp(root) {
       <section class="jobs" aria-label="Recent jobs">
         <div class="section-heading section-heading-with-action">
           <h2>Recent jobs</h2>
-          <div style="display: flex; gap: 8px;">
+          <div style="display: flex; gap: 8px; align-items: center;">
+            <select id="job-status-filter" class="job-status-filter clear-history-btn" aria-label="Filter jobs by status">
+              <option value="All">All</option>
+              <option value="Queued">Queued</option>
+              <option value="Running">Running</option>
+              <option value="Completed">Completed</option>
+              <option value="Failed">Failed</option>
+              <option value="Cancelled">Cancelled</option>
+            </select>
             <a href="/api/history/download" id="download-all-btn" class="clear-history-btn" download style="text-decoration: none; display: none;">Download all completed</a>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
           </div>
@@ -145,6 +153,7 @@ export function renderApp(root) {
   const input = root.querySelector("#spotify-url");
   const feedback = root.querySelector("#queue-feedback");
   const jobList = root.querySelector("#job-list");
+  const statusFilter = root.querySelector("#job-status-filter");
 
   async function updateProgress(jobId) {
     const container = root.querySelector(`#progress-container-${jobId}`);
@@ -183,10 +192,17 @@ export function renderApp(root) {
         downloadAllBtn.style.display = hasCompleted ? "inline-flex" : "none";
       }
 
-      if (jobs.length === 0) {
-        jobList.innerHTML = `<p class="empty-state">No jobs yet.</p>`;
+      const selectedStatus = statusFilter ? statusFilter.value : "All";
+      const filteredJobs = selectedStatus === "All" ? jobs : jobs.filter(job => job.status === selectedStatus);
+
+      if (filteredJobs.length === 0) {
+        if (jobs.length === 0) {
+          jobList.innerHTML = `<p class="empty-state">No jobs yet.</p>`;
+        } else {
+          jobList.innerHTML = `<p class="empty-state">No jobs match the selected filter.</p>`;
+        }
       } else {
-        jobList.innerHTML = jobs.map(renderJob).join("");
+        jobList.innerHTML = filteredJobs.map(renderJob).join("");
 
         // Fetch progress for running jobs
         for (const job of jobs) {
@@ -199,6 +215,10 @@ export function renderApp(root) {
       console.error(err);
       jobList.innerHTML = `<p class="error-state">Failed to load jobs.</p>`;
     }
+  }
+
+  if (statusFilter) {
+    statusFilter.addEventListener("change", fetchJobs);
   }
 
   // Initial load

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -529,6 +529,28 @@ button:active {
   border: 1px solid rgba(31, 122, 77, 0.1);
 }
 
+.job-status-filter {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 16px;
+  padding-right: 32px;
+  outline: none;
+}
+
+.job-status-filter:focus {
+  border-color: var(--glass-border);
+  box-shadow: 0 0 0 2px var(--input-shadow-focus);
+}
+
+.job-status-filter option {
+  background-color: var(--bg-body);
+  color: var(--text-primary);
+}
+
 .clear-history-btn {
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -414,3 +414,59 @@ test("toggles dark mode", async ({ page }) => {
   await themeToggle.click();
   await expect(html).not.toHaveClass(/dark/);
 });
+
+test("filters jobs by status", async ({ page }) => {
+  // Add a Queued job to the mock to test filtering
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "123",
+            url: "https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 10,
+            error_log: null
+          },
+          {
+            id: "125",
+            url: "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC",
+            status: "Queued",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+        await route.continue();
+    }
+  });
+
+  await page.goto("/");
+
+  // Initially shows both jobs
+  await expect(page.locator(".job-card")).toHaveCount(2);
+
+  // Filter by Completed
+  await page.locator("#job-status-filter").selectOption("Completed");
+  await expect(page.locator(".job-card")).toHaveCount(1);
+  await expect(page.locator(".job-card")).toContainText("Completed");
+
+  // Filter by Queued
+  await page.locator("#job-status-filter").selectOption("Queued");
+  await expect(page.locator(".job-card")).toHaveCount(1);
+  await expect(page.locator(".job-card")).toContainText("Queued");
+
+  // Filter by Failed (no jobs should match)
+  await page.locator("#job-status-filter").selectOption("Failed");
+  await expect(page.locator(".job-card")).toHaveCount(0);
+  await expect(page.locator(".empty-state")).toContainText("No jobs match the selected filter.");
+
+  // Filter by All
+  await page.locator("#job-status-filter").selectOption("All");
+  await expect(page.locator(".job-card")).toHaveCount(2);
+});


### PR DESCRIPTION
This PR introduces a job status filter dropdown to the SpotiFLAC web interface, as specified in the backlog.

* **UI Element:** A styled `<select>` element was added next to the "Clear history" button.
* **Functionality:** Filtering the list dynamically by matching job status. Handles edge cases where no jobs match the active filter.
* **Testing:** Included a Playwright UI test validating "All", "Completed", and "Failed" statuses.

---
*PR created automatically by Jules for task [6789619341759714236](https://jules.google.com/task/6789619341759714236) started by @jjgroenendijk*