### PR TITLE
feat: add track cover images to job history

### DIFF
--- a/server.py
+++ b/server.py
@@ -212,6 +212,37 @@ async def get_job_file(job_id: str, file_path: str):
     return FileResponse(target_file)
 
 
+@app.get("/api/jobs/{job_id}/cover")
+async def get_job_cover(job_id: str):
+    import re
+    # Strict validation of job_id to prevent path traversal
+    if not re.match(r"^[a-zA-Z0-9-]+$", job_id):
+        raise HTTPException(status_code=400, detail="Invalid job ID format")
+
+    job_dir = (DATA_DIR / job_id).resolve()
+
+    # Extra check to ensure job_dir is still within DATA_DIR
+    if not job_dir.is_relative_to(DATA_DIR.resolve()):
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    if not job_dir.exists() or not job_dir.is_dir():
+        raise HTTPException(status_code=404, detail="Job directory not found")
+
+    try:
+        # Search for common image formats
+        for ext in ("*.jpg", "*.jpeg", "*.png"):
+            for p in job_dir.rglob(ext):
+                if p.is_file():
+                    return FileResponse(p)
+
+        raise HTTPException(status_code=404, detail="Cover not found")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error finding cover for {job_id}: {e}")
+        raise HTTPException(status_code=500, detail="Error finding cover")
+
+
 @app.get("/api/jobs/{job_id}/files")
 async def get_job_files(job_id: str):
     import re

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -249,6 +249,53 @@ def test_download_single_file_not_found(tmp_path, monkeypatch):
     response = client.get(f"/api/jobs/{job_id}/files/missing_file.txt")
     assert response.status_code == 404
 
+def test_get_job_cover_success(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr("server.DATA_DIR", data_dir)
+
+    job_id = "test-job-cover-success"
+    job_dir = data_dir / job_id
+    job_dir.mkdir()
+
+    # Create a dummy image file
+    cover_file = job_dir / "cover.jpg"
+    cover_file.write_text("dummy image data")
+
+    response = client.get(f"/api/jobs/{job_id}/cover")
+    assert response.status_code == 200
+    assert response.text == "dummy image data"
+
+
+def test_get_job_cover_not_found(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr("server.DATA_DIR", data_dir)
+
+    job_id = "test-job-cover-not-found"
+    job_dir = data_dir / job_id
+    job_dir.mkdir()
+
+    # No images here
+    response = client.get(f"/api/jobs/{job_id}/cover")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Cover not found"}
+
+
+def test_get_job_cover_invalid_job_id():
+    response = client.get("/api/jobs/invalid..id/cover")
+    assert response.status_code == 400
+
+
+def test_get_job_cover_job_not_found(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr("server.DATA_DIR", data_dir)
+
+    response = client.get("/api/jobs/nonexistent-job/cover")
+    assert response.status_code == 404
+
+
 def test_download_single_file_path_traversal(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -49,6 +49,7 @@ function renderJob(job) {
 
   return `
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">
+      <img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.style.display='none'" alt="Cover art" />
       <div>
         <p class="job-title">${escapeHtml(job.url)}</p>
         <p class="job-source">Started: ${new Date(job.created_at).toLocaleString()}</p>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -344,11 +344,20 @@ button:active {
 
 .job-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 18px;
   align-items: center;
   padding: 16px;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.track-cover {
+  width: 64px;
+  height: 64px;
+  border-radius: 8px;
+  object-fit: cover;
+  box-shadow: 0 4px 12px 0 var(--glass-shadow);
+  flex-shrink: 0;
 }
 
 .job-card:hover {


### PR DESCRIPTION
This PR implements the track cover view for the SpotiFLAC web application.

Changes:
- Backend: Exposes an endpoint (`/api/jobs/{job_id}/cover`) to retrieve `cover.jpg`, `cover.png`, or `cover.jpeg` for a downloaded job from `DATA_DIR`. Added passing Pytest unit tests.
- Frontend: Updates `app.js` to render `<img class="track-cover" src="/api/jobs/{id}/cover" onerror="...">` for each job item. Modifies `styles.css` to integrate the cover into the existing Liquid Glass grid seamlessly, matching design constraints.
- Verification: End-to-end frontend visual test using Playwright confirms UI displays beautifully. Tests built via `npm run build`, `npm run test`, and `pytest` are fully passing.

Closes requirements from `docs/requirements.md`.

---
*PR created automatically by Jules for task [6364690592294094768](https://jules.google.com/task/6364690592294094768) started by @jjgroenendijk*