### PR TITLE
feat: Add confirmation prompt before clearing history

### DIFF
--- a/docs/backlog/closed/confirm-clear-history.md
+++ b/docs/backlog/closed/confirm-clear-history.md
@@ -1,0 +1,3 @@
+# Confirm Clear History
+
+As a user, I want to be prompted for confirmation when I click the 'Clear history' button, so that I don't accidentally delete all my non-running job history.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -469,6 +469,9 @@ export function renderApp(root) {
   const clearHistoryBtn = root.querySelector("#clear-history-btn");
   if (clearHistoryBtn) {
     clearHistoryBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to clear all non-running job history? This cannot be undone.")) {
+        return;
+      }
       clearHistoryBtn.disabled = true;
       clearHistoryBtn.textContent = "Clearing...";
       try {

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -345,6 +345,7 @@ test("can clear job history", async ({ page }) => {
   const clearBtn = page.getByRole("button", { name: "Clear history" });
   await expect(clearBtn).toBeVisible();
 
+  page.once("dialog", dialog => dialog.accept());
   await clearBtn.click();
 
   // Playwright executes the mock fetch almost instantly, so we might miss the 'Clearing...' text.


### PR DESCRIPTION
This PR adds a safety confirmation prompt before deleting all completed and failed job histories. This prevents accidental single-click deletions that cannot be undone.

- Added `window.confirm` check in `app.js` click handler.
- Added `page.once("dialog", dialog => dialog.accept())` to Playwright tests to ensure tests remain fully functional.

---
*PR created automatically by Jules for task [9178486149953035722](https://jules.google.com/task/9178486149953035722) started by @jjgroenendijk*