### PR TITLE
feat: display spotify url type badge on job cards

### DIFF
--- a/docs/backlog/closed/url-type-badges.md
+++ b/docs/backlog/closed/url-type-badges.md
@@ -1,0 +1,9 @@
+# URL Type Badges
+
+## Goal
+Display the type of Spotify URL (track, album, or playlist) on the job card to help users distinguish their queued items at a glance.
+
+## Details
+- Use the existing `classifySpotifyUrl` function to determine the type of the job's URL.
+- Render a small badge or text label (e.g., "Track", "Album", "Playlist") next to the job title on the job card.
+- Ensure the badge is styled appropriately.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -46,12 +46,13 @@ function renderJob(job) {
   const downloadZipBtnHtml = job.status === "Completed" ? `<a href="/api/jobs/${escapeHtml(job.id)}/download" download class="download-zip-btn view-files-btn">Download ZIP</a>` : "";
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
+  const urlType = classifySpotifyUrl(job.url);
 
   return `
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">
       <img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.style.display='none'" alt="Cover art" />
       <div>
-        <p class="job-title">${escapeHtml(job.url)}</p>
+        <p class="job-title">${escapeHtml(job.url)} <span class="url-type-badge" style="font-size: 0.75rem; background: rgba(255,255,255,0.2); padding: 2px 6px; border-radius: 4px; margin-left: 8px; text-transform: capitalize; vertical-align: middle;">${escapeHtml(urlType)}</span></p>
         <p class="job-source">Started: ${new Date(job.created_at).toLocaleString()}</p>
       </div>
       <div class="job-meta">

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -82,6 +82,10 @@ describe("renderApp", () => {
       })
     );
 
+    const badge = document.querySelector('.url-type-badge');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toBe('track');
+
     // Simulate clicking "View Files"
     viewFilesBtn.click();
 


### PR DESCRIPTION
This commit implements the URL Type Badges feature. It adds a visual indicator on the job card to display whether the queued URL is a "track", "album", or "playlist". It uses the `classifySpotifyUrl` function to determine the type and renders it as an inline badge next to the job title. It also updates the existing Playwright and Vitest tests, and completes the associated backlog item.

---
*PR created automatically by Jules for task [2942343342034737126](https://jules.google.com/task/2942343342034737126) started by @jjgroenendijk*