### PR TITLE
feat: allow bulk queuing of multiple Spotify URLs

### DIFF
--- a/docs/backlog/closed/016-bulk-queue-urls.md
+++ b/docs/backlog/closed/016-bulk-queue-urls.md
@@ -1,0 +1,2 @@
+# Requirement: Bulk Queue URLs
+- As a user, I want a way to submit multiple Spotify URLs at once by pasting them into a multiline input, so that I can queue several jobs efficiently without having to submit them one by one.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -106,16 +106,16 @@ export function renderApp(root) {
 
       <section class="workspace" aria-label="SpotiFLAC queue">
         <form class="queue-panel" id="queue-form">
-          <label for="spotify-url">Spotify URL</label>
+          <label for="spotify-url">Spotify URLs</label>
           <div class="url-row">
-            <input
+            <textarea
               id="spotify-url"
               name="spotify-url"
-              type="url"
               placeholder="https://open.spotify.com/album/..."
               autocomplete="off"
               required
-            />
+              rows="3"
+            ></textarea>
             <button type="submit">Queue</button>
           </div>
           <p class="hint" id="queue-feedback">Tracks, albums, and playlists will run through the SpotiFLAC module.</p>
@@ -293,32 +293,63 @@ export function renderApp(root) {
 
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
-    const value = input.value.trim();
 
-    if (!isSpotifyUrl(value)) {
-      feedback.textContent = "Enter a Spotify track, album, or playlist URL.";
+    // Split input by any whitespace, filter out empty strings
+    const urls = input.value.split(/\s+/).filter(Boolean);
+
+    if (urls.length === 0) {
+      feedback.textContent = "Enter at least one Spotify URL.";
       feedback.dataset.state = "error";
       return;
     }
 
-    try {
-      const response = await fetch("/api/jobs", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: value })
-      });
+    const invalidUrls = urls.filter(url => !isSpotifyUrl(url));
+    if (invalidUrls.length > 0) {
+      feedback.textContent = "One or more URLs are invalid. Ensure they are valid Spotify track, album, or playlist URLs.";
+      feedback.dataset.state = "error";
+      return;
+    }
 
-      if (!response.ok) throw new Error("Failed to queue");
+    const queueBtn = form.querySelector('button[type="submit"]');
+    queueBtn.disabled = true;
+    queueBtn.textContent = "Queueing...";
+
+    try {
+      const requests = urls.map(url =>
+        fetch("/api/jobs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url })
+        })
+      );
+
+      const responses = await Promise.allSettled(requests);
+
+      const failedCount = responses.filter(r => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok)).length;
+      const successCount = responses.length - failedCount;
+
+      if (successCount === 0) {
+        throw new Error("Failed to queue all jobs");
+      }
 
       input.value = "";
-      feedback.textContent = "Job queued successfully.";
-      feedback.dataset.state = "success";
+
+      if (failedCount === 0) {
+        feedback.textContent = `Successfully queued ${successCount} job${successCount > 1 ? 's' : ''}.`;
+        feedback.dataset.state = "success";
+      } else {
+        feedback.textContent = `Queued ${successCount} job${successCount > 1 ? 's' : ''}, but failed to queue ${failedCount}.`;
+        feedback.dataset.state = "error"; // Show orange/red to indicate partial failure
+      }
 
       // Refresh list immediately
       fetchJobs();
     } catch (err) {
-      feedback.textContent = "Error queueing job.";
+      feedback.textContent = "Error queueing jobs.";
       feedback.dataset.state = "error";
+    } finally {
+      queueBtn.disabled = false;
+      queueBtn.textContent = "Queue";
     }
   });
 

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -114,7 +114,8 @@ body {
 }
 
 button,
-input {
+input,
+textarea {
   font: inherit;
 }
 
@@ -253,7 +254,8 @@ label {
   gap: 10px;
 }
 
-input {
+input,
+textarea {
   width: 100%;
   min-height: 48px;
   border: 1px solid var(--input-border);
@@ -267,7 +269,14 @@ input {
   transition: all 0.2s ease;
 }
 
-input:focus {
+textarea {
+  padding: 12px 14px;
+  resize: vertical;
+  min-height: 80px;
+}
+
+input:focus,
+textarea:focus {
   outline: none;
   background: var(--input-bg-focus);
   border-color: var(--input-border-focus);

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -47,7 +47,7 @@ test("shows the SpotiFLAC queue shell and fetched jobs", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("heading", { name: "SpotiFLAC" })).toBeVisible();
-  await expect(page.getByLabel("Spotify URL")).toBeVisible();
+  await expect(page.getByLabel("Spotify URLs")).toBeVisible();
   await expect(page.getByText("/data", { exact: true })).toBeVisible();
   await expect(page.getByText("10 files")).toBeVisible();
 });
@@ -55,10 +55,46 @@ test("shows the SpotiFLAC queue shell and fetched jobs", async ({ page }) => {
 test("validates supported Spotify URLs and queues job", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByLabel("Spotify URL").fill("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M");
+  await page.getByLabel("Spotify URLs").fill("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M");
   await page.getByRole("button", { name: "Queue" }).click();
 
-  await expect(page.getByText("Job queued successfully.")).toBeVisible();
+  await expect(page.getByText("Successfully queued 1 job.")).toBeVisible();
+});
+
+test("validates and queues multiple Spotify URLs", async ({ page }) => {
+  await page.goto("/");
+
+  // Mock the /api/jobs endpoint to intercept requests
+  const requests = [];
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "POST") {
+      requests.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: `mock-job-${requests.length}`,
+          url: route.request().postDataJSON().url,
+          status: "Queued",
+          created_at: new Date().toISOString(),
+          files: 0
+        })
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  const urls = "https://open.spotify.com/track/123\nhttps://open.spotify.com/album/456\n  https://open.spotify.com/playlist/789  ";
+  await page.getByLabel("Spotify URLs").fill(urls);
+  await page.getByRole("button", { name: "Queue" }).click();
+
+  await expect(page.getByText("Successfully queued 3 jobs.")).toBeVisible();
+
+  expect(requests).toHaveLength(3);
+  expect(requests[0].url).toBe("https://open.spotify.com/track/123");
+  expect(requests[1].url).toBe("https://open.spotify.com/album/456");
+  expect(requests[2].url).toBe("https://open.spotify.com/playlist/789");
 });
 
 


### PR DESCRIPTION
Allows users to paste multiple Spotify URLs into a new textarea input and queue them all at once. The form handles splitting by newlines or spaces, filters empty entries, validates each URL, and displays appropriate success or error feedback indicating how many jobs successfully queued. Playwright tests have been updated to reflect the textarea change and a new test covers the multiple URL queuing logic.

---
*PR created automatically by Jules for task [1068982643052776432](https://jules.google.com/task/1068982643052776432) started by @jjgroenendijk*