### PR TITLE
feat: make job source URLs clickable links in the UI

### DIFF
--- a/docs/backlog/closed/017_clickable_job_urls.md
+++ b/docs/backlog/closed/017_clickable_job_urls.md
@@ -1,0 +1,6 @@
+# Make job source URLs clickable links
+
+**Goal**: Make the job source URLs displayed in the SpotiFLAC web UI clickable links that open in a new tab.
+
+**Details**:
+Currently, the URLs (like `https://open.spotify.com/...`) are displayed as plain text in the `.job-title` element. To improve user experience, these should be rendered as clickable `<a>` tags with `target="_blank"` and `rel="noopener noreferrer"`. The link should inherit text styling so it integrates smoothly with the existing liquid glass design.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -52,7 +52,10 @@ function renderJob(job) {
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">
       <img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.style.display='none'" alt="Cover art" />
       <div>
-        <p class="job-title">${escapeHtml(job.url)} <span class="url-type-badge" style="font-size: 0.75rem; background: rgba(255,255,255,0.2); padding: 2px 6px; border-radius: 4px; margin-left: 8px; text-transform: capitalize; vertical-align: middle;">${escapeHtml(urlType)}</span></p>
+        <p class="job-title">
+          <a href="${escapeHtml(job.url)}" target="_blank" rel="noopener noreferrer" class="source-link">${escapeHtml(job.url)}</a>
+          <span class="url-type-badge" style="font-size: 0.75rem; background: rgba(255,255,255,0.2); padding: 2px 6px; border-radius: 4px; margin-left: 8px; text-transform: capitalize; vertical-align: middle;">${escapeHtml(urlType)}</span>
+        </p>
         <p class="job-source">Started: ${new Date(job.created_at).toLocaleString()}</p>
       </div>
       <div class="job-meta">

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -379,6 +379,17 @@ button:active {
   font-weight: 800;
 }
 
+.source-link {
+  color: inherit;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.source-link:hover {
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
 .job-source {
   margin-bottom: 0;
   overflow-wrap: anywhere;

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -567,3 +567,42 @@ test("filters jobs by status", async ({ page }) => {
   await page.locator("#job-status-filter").selectOption("All");
   await expect(page.locator(".job-card")).toHaveCount(2);
 });
+
+test("job URLs are rendered as clickable links", async ({ page }) => {
+  // Use the mocked API route to provide a job
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "123",
+            url: "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 1,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  // Wait for the job card to load
+  const jobCard = page.locator(".job-card").first();
+  await expect(jobCard).toBeVisible();
+
+  // Find the source link inside the job title
+  const sourceLink = jobCard.locator(".job-title a.source-link");
+  await expect(sourceLink).toBeVisible();
+
+  // Verify href and attributes
+  await expect(sourceLink).toHaveAttribute("href", "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC");
+  await expect(sourceLink).toHaveAttribute("target", "_blank");
+  await expect(sourceLink).toHaveAttribute("rel", "noopener noreferrer");
+});


### PR DESCRIPTION
This change introduces a new feature to the UI: making the job source URLs clickable links.

- Modified `app.js` to render the `.job-title` text as an anchor tag (`<a>`) using the `source-link` CSS class.
- Added CSS for `.source-link` to `styles.css` removing the default underline but displaying it with full opacity on hover.
- Added a playwright test in `web-ui.spec.js` to verify the link renders correctly with the proper `href`, `target`, and `rel` attributes.
- Completed and closed backlog item `017_clickable_job_urls.md`.

---
*PR created automatically by Jules for task [16986010886283124994](https://jules.google.com/task/16986010886283124994) started by @jjgroenendijk*