### PR TITLE
feat: sort jobs by newest first in UI

### DIFF
--- a/docs/backlog/closed/sort_jobs_newest_first.md
+++ b/docs/backlog/closed/sort_jobs_newest_first.md
@@ -1,0 +1,9 @@
+# Sort Jobs by Newest First
+
+## Objective
+The SpotiFLAC web UI currently displays jobs in the order they are returned by the API. To improve user experience, the UI should display the most recently created jobs at the top.
+
+## Requirements
+- Sort jobs by the `created_at` field in descending order (newest first) in the frontend before rendering.
+- Update unit tests in `app.test.js` to verify this sorting behavior.
+- Run quality checks and move this file to `closed/` upon completion.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -202,8 +202,11 @@ export function renderApp(root) {
         downloadAllBtn.style.display = hasCompleted ? "inline-flex" : "none";
       }
 
+      // Sort jobs by newest first
+      const sortedJobs = [...jobs].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
       const selectedStatus = statusFilter ? statusFilter.value : "All";
-      const filteredJobs = selectedStatus === "All" ? jobs : jobs.filter(job => job.status === selectedStatus);
+      const filteredJobs = selectedStatus === "All" ? sortedJobs : sortedJobs.filter(job => job.status === selectedStatus);
 
       if (filteredJobs.length === 0) {
         if (jobs.length === 0) {

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -104,6 +104,59 @@ describe("renderApp", () => {
     cleanup();
   });
 
+  it("sorts jobs by newest first", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+
+    global.localStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+    global.window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: false,
+    }));
+
+    const root = document.getElementById("root");
+
+    // Mock fetch jobs returning two jobs out of order
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([
+          {
+            id: "older-job",
+            url: "https://open.spotify.com/track/old",
+            status: "Completed",
+            created_at: "2023-01-01T00:00:00Z",
+            files: 1
+          },
+          {
+            id: "newer-job",
+            url: "https://open.spotify.com/track/new",
+            status: "Queued",
+            created_at: "2024-01-01T00:00:00Z",
+            files: 0
+          }
+        ])
+      })
+    );
+
+    const cleanup = renderApp(root);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const jobCards = document.querySelectorAll(".job-card");
+    expect(jobCards.length).toBe(2);
+    // The newer job should be rendered first
+    expect(jobCards[0].getAttribute("data-job-id")).toBe("newer-job");
+    expect(jobCards[1].getAttribute("data-job-id")).toBe("older-job");
+
+    cleanup();
+  });
+
   it("toggles dark mode and updates localStorage", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",


### PR DESCRIPTION
This PR introduces a feature to sort SpotiFLAC jobs by newest first in the web UI.

**Changes:**
- Implemented sorting logic in `website/src/app.js` based on `created_at` timestamp.
- Created `website/src/app.test.js` to mock requirements and add unit tests to ensure accurate chronological rendering.
- Added documentation reflecting the completion of the backlog item by moving it from `docs/backlog/open/` to `docs/backlog/closed/`.

---
*PR created automatically by Jules for task [6590814700268469852](https://jules.google.com/task/6590814700268469852) started by @jjgroenendijk*