### PR TITLE
Add Playwright test for Download all completed button

### DIFF
--- a/docs/backlog/closed/download-all-as-zip-test.md
+++ b/docs/backlog/closed/download-all-as-zip-test.md
@@ -1,0 +1,7 @@
+# Playwright test for 'Download all completed' button
+
+## Requirement
+The UI has a "Download all completed" button that triggers a download of all completed jobs as a ZIP archive. This functionality should be covered by a Playwright test to ensure it remains working.
+
+## Tasks
+1. Add a Playwright test in `website/tests/web-ui.spec.js` to verify that the "Download all completed" button appears when there are completed jobs, and successfully triggers a download via `/api/history/download`.

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -502,6 +502,37 @@ test('displays Download ZIP link for completed jobs', async ({ page }) => {
   await expect(downloadLink).toHaveAttribute('download', '');
 });
 
+test('displays Download all completed button when completed jobs exist', async ({ page }) => {
+  // Use the mocked API route to provide a completed job
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: '123',
+            url: 'https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX',
+            status: 'Completed',
+            created_at: new Date().toISOString(),
+            files: 10,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  const downloadAllBtn = page.locator('#download-all-btn');
+  await expect(downloadAllBtn).toBeVisible();
+  await expect(downloadAllBtn).toHaveAttribute('href', '/api/history/download');
+  await expect(downloadAllBtn).toHaveAttribute('download', '');
+});
+
 test("toggles dark mode", async ({ page }) => {
   await page.goto("/");
   const themeToggle = page.locator("#theme-toggle");


### PR DESCRIPTION
- Added a Playwright test case in `website/tests/web-ui.spec.js` for the "Download all completed" button.
- The test verifies visibility and attributes (`href`, `download`) when there is a "Completed" job mocked.
- Moved `download-all-as-zip-test.md` to `docs/backlog/closed/`.

---
*PR created automatically by Jules for task [9490774770648618118](https://jules.google.com/task/9490774770648618118) started by @jjgroenendijk*