### PR TITLE
feat: add job search filter by URL or ID

### DIFF
--- a/docs/backlog/closed/018-search-jobs.md
+++ b/docs/backlog/closed/018-search-jobs.md
@@ -1,0 +1,10 @@
+# Search jobs by URL or ID
+
+Users need to quickly find specific jobs, especially when the queue gets long.
+Add a search input box in the "Recent jobs" section that filters the displayed jobs by checking if the search text is present in the job URL or job ID.
+The search should be case-insensitive and update as the user types (or when `fetchJobs` is triggered).
+
+## Requirements
+1. Add a text input field to the recent jobs header.
+2. Filter the `jobs` list fetched from `/api/jobs` on the frontend before rendering.
+3. Update unit/e2e tests in Playwright to verify filtering behavior.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -135,6 +135,7 @@ export function renderApp(root) {
         <div class="section-heading section-heading-with-action">
           <h2>Recent jobs</h2>
           <div style="display: flex; gap: 8px; align-items: center;">
+            <input type="text" id="job-search-input" placeholder="Search URL or ID..." class="job-search-input" aria-label="Search jobs" />
             <select id="job-status-filter" class="job-status-filter clear-history-btn" aria-label="Filter jobs by status">
               <option value="All">All</option>
               <option value="Queued">Queued</option>
@@ -164,6 +165,7 @@ export function renderApp(root) {
   const feedback = root.querySelector("#queue-feedback");
   const jobList = root.querySelector("#job-list");
   const statusFilter = root.querySelector("#job-status-filter");
+  const searchInput = root.querySelector("#job-search-input");
 
   async function updateProgress(jobId) {
     const container = root.querySelector(`#progress-container-${jobId}`);
@@ -229,11 +231,21 @@ export function renderApp(root) {
       const sortedJobs = [...jobs].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
       const selectedStatus = statusFilter ? statusFilter.value : "All";
-      const filteredJobs = selectedStatus === "All" ? sortedJobs : sortedJobs.filter(job => job.status === selectedStatus);
+      let filteredJobs = selectedStatus === "All" ? sortedJobs : sortedJobs.filter(job => job.status === selectedStatus);
+
+      const searchQuery = searchInput ? searchInput.value.trim().toLowerCase() : "";
+      if (searchQuery) {
+        filteredJobs = filteredJobs.filter(job =>
+          (job.url && job.url.toLowerCase().includes(searchQuery)) ||
+          (job.id && job.id.toLowerCase().includes(searchQuery))
+        );
+      }
 
       if (filteredJobs.length === 0) {
         if (jobs.length === 0) {
           jobList.innerHTML = `<p class="empty-state">No jobs yet.</p>`;
+        } else if (searchQuery) {
+          jobList.innerHTML = `<p class="empty-state">No jobs match the search query.</p>`;
         } else {
           jobList.innerHTML = `<p class="empty-state">No jobs match the selected filter.</p>`;
         }
@@ -255,6 +267,14 @@ export function renderApp(root) {
 
   if (statusFilter) {
     statusFilter.addEventListener("change", fetchJobs);
+  }
+
+  if (searchInput) {
+    let debounceTimer;
+    searchInput.addEventListener("input", () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(fetchJobs, 300);
+    });
   }
 
   const autoRefreshToggle = root.querySelector("#auto-refresh-toggle");

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -570,7 +570,8 @@ button:active {
   outline: none;
 }
 
-.job-status-filter:focus {
+.job-status-filter:focus,
+.job-search-input:focus {
   border-color: var(--glass-border);
   box-shadow: 0 0 0 2px var(--input-shadow-focus);
 }
@@ -578,6 +579,26 @@ button:active {
 .job-status-filter option {
   background-color: var(--bg-body);
   color: var(--text-primary);
+}
+
+.job-search-input {
+  min-height: auto;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.job-search-input:focus {
+  outline: none;
+  background: var(--input-bg-focus);
+}
+
+.job-search-input::placeholder {
+  color: var(--text-tertiary);
 }
 
 .clear-history-btn {

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -637,3 +637,58 @@ test("job URLs are rendered as clickable links", async ({ page }) => {
   await expect(sourceLink).toHaveAttribute("target", "_blank");
   await expect(sourceLink).toHaveAttribute("rel", "noopener noreferrer");
 });
+
+test('search input filters jobs by URL and ID', async ({ page }) => {
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-111',
+            url: 'https://open.spotify.com/track/alpha',
+            status: 'Completed',
+            created_at: new Date(Date.now() - 2000).toISOString(),
+            files: 1,
+            error_log: null
+          },
+          {
+            id: 'job-222',
+            url: 'https://open.spotify.com/album/beta',
+            status: 'Queued',
+            created_at: new Date(Date.now() - 1000).toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ])
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  // Wait for initial jobs to load
+  await expect(page.locator('.job-card')).toHaveCount(2);
+
+  // Search by URL substring
+  await page.fill('#job-search-input', 'alpha');
+  await expect(page.locator('.job-card')).toHaveCount(1);
+  await expect(page.locator('.job-card').first()).toContainText('alpha');
+
+  // Search by ID substring
+  await page.fill('#job-search-input', '222');
+  await expect(page.locator('.job-card')).toHaveCount(1);
+  await expect(page.locator('.job-card').first()).toContainText('beta');
+
+  // Search with no matches
+  await page.fill('#job-search-input', 'nonexistent');
+  await expect(page.locator('.job-card')).toHaveCount(0);
+  await expect(page.locator('.empty-state')).toContainText('No jobs match the search query.');
+
+  // Clear search
+  await page.fill('#job-search-input', '');
+  await expect(page.locator('.job-card')).toHaveCount(2);
+});


### PR DESCRIPTION
Implemented the "Search jobs by URL or ID" feature requested in backlog item 018.

- Added a debounced search input field to the recent jobs header.
- Updated `fetchJobs` in `app.js` to filter the jobs array based on substring matches in `job.url` or `job.id` before rendering.
- Styled the input to match the liquid glass aesthetic.
- Updated empty state messages to handle search query mismatches.
- Added a Playwright test to ensure filtering works correctly.

---
*PR created automatically by Jules for task [2781261442740913220](https://jules.google.com/task/2781261442740913220) started by @jjgroenendijk*