### PR TITLE
feat: add "Clear failed" button to history UI

### DIFF
--- a/docs/backlog/closed/clear-failed-jobs.md
+++ b/docs/backlog/closed/clear-failed-jobs.md
@@ -1,0 +1,8 @@
+# Clear Failed Jobs
+
+## Problem
+Currently, the UI has a "Clear history" button that clears all non-running history. However, users who occasionally encounter failed downloads have no easy way to clear *only* the failed jobs without losing their successfully completed history.
+
+## Solution
+Add a "Clear failed" button next to the "Clear history" button.
+When clicked, it sends a `DELETE` request to a new `/api/history/clear-failed` endpoint on the backend, which will remove all jobs with `status == "Failed"` from the `history.json` and clean up their associated files/logs.

--- a/server.py
+++ b/server.py
@@ -436,6 +436,32 @@ async def clear_history():
 
     return {"status": "success", "cleared": len(cleared_jobs)}
 
+@app.delete("/api/history/clear-failed")
+async def clear_failed_history():
+    history = []
+    cleared_jobs = []
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        filtered_history = []
+        for job in history:
+            if job.get("status") == "Failed":
+                cleared_jobs.append(job["id"])
+            else:
+                filtered_history.append(job)
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(filtered_history, f, indent=2)
+
+    for job_id in cleared_jobs:
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        await asyncio.to_thread(_delete_job_files, job_id)
+
+    return {"status": "success", "cleared": len(cleared_jobs)}
+
 @app.delete("/api/jobs/{job_id}")
 async def cancel_job(job_id: str):
     history = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -58,6 +58,35 @@ def test_cancel_nonexistent_job():
     response = client.delete("/api/jobs/not-a-real-id")
     assert response.status_code == 404
 
+def test_clear_failed_history():
+    import json
+
+    # Write some dummy jobs directly to history file
+    dummy_history = [
+        {"id": "job-1", "url": "https://open.spotify.com/track/abc", "status": "Failed"},
+        {"id": "job-2", "url": "https://open.spotify.com/track/def", "status": "Completed"},
+        {"id": "job-3", "url": "https://open.spotify.com/track/ghi", "status": "Failed"},
+        {"id": "job-4", "url": "https://open.spotify.com/track/jkl", "status": "Running"}
+    ]
+    with open(HISTORY_FILE, "w") as f:
+        json.dump(dummy_history, f)
+
+    resp = client.delete("/api/history/clear-failed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert data["cleared"] == 2
+
+    resp = client.get("/api/jobs")
+    assert resp.status_code == 200
+    remaining_jobs = resp.json()
+
+    assert len(remaining_jobs) == 2
+    statuses = [j["status"] for j in remaining_jobs]
+    assert "Completed" in statuses
+    assert "Running" in statuses
+    assert "Failed" not in statuses
+
 def test_get_job_log(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -150,6 +150,7 @@ export function renderApp(root) {
               <input type="checkbox" id="auto-refresh-toggle" style="width: auto; min-height: auto; margin: 0; cursor: pointer;">
               Auto-refresh
             </label>
+            <button type="button" id="clear-failed-btn" class="clear-history-btn" style="border-color: rgba(220, 38, 38, 0.5); color: #dc2626;">Clear failed</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
           </div>
         </div>
@@ -594,6 +595,28 @@ export function renderApp(root) {
       } finally {
         clearHistoryBtn.disabled = false;
         clearHistoryBtn.textContent = "Clear history";
+      }
+    });
+  }
+
+  const clearFailedBtn = root.querySelector("#clear-failed-btn");
+  if (clearFailedBtn) {
+    clearFailedBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to clear all failed jobs? This cannot be undone.")) {
+        return;
+      }
+      clearFailedBtn.disabled = true;
+      clearFailedBtn.textContent = "Clearing...";
+      try {
+        const response = await fetch("/api/history/clear-failed", { method: "DELETE" });
+        if (response.ok) {
+          fetchJobs();
+        }
+      } catch (err) {
+        console.error("Failed to clear failed jobs", err);
+      } finally {
+        clearFailedBtn.disabled = false;
+        clearFailedBtn.textContent = "Clear failed";
       }
     });
   }

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -172,4 +172,45 @@ describe("renderApp", () => {
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     expect(global.localStorage.setItem).toHaveBeenCalledWith("theme", "dark");
   });
+
+  it("calls the clear-failed endpoint and refreshes when Clear failed is clicked", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    // Mock confirm to simulate user clicking "OK"
+    global.window.confirm = vi.fn(() => true);
+
+    const root = document.getElementById("root");
+
+    // Setup fetch mock to track calls
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementation((url, options) => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+    global.fetch = fetchMock;
+
+    renderApp(root);
+
+    // The initial fetchJobs triggers fetch('/api/jobs') and updateStorageUsage triggers fetch('/api/system/storage')
+    // We want to verify the specific DELETE call when the button is clicked.
+
+    const clearFailedBtn = document.getElementById("clear-failed-btn");
+    expect(clearFailedBtn).not.toBeNull();
+
+    clearFailedBtn.click();
+
+    // Allow async handlers to complete
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(global.window.confirm).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith("/api/history/clear-failed", { method: "DELETE" });
+  });
 });


### PR DESCRIPTION
This PR implements the autonomous requirement from `docs/backlog/closed/clear-failed-jobs.md` to introduce a "Clear failed" button.

### Changes
* **Frontend:** Added `#clear-failed-btn` with a confirmation dialog to delete only `status === 'Failed'` jobs. Wired the UI up to call the new endpoint.
* **Backend:** Implemented `DELETE /api/history/clear-failed` in `server.py` to filter `history.json` and delete the associated `DATA_DIR` and `LOGS_DIR` files for failed jobs while holding the `history_lock`.
* **Testing:** Included unit tests for the frontend (`website/src/app.test.js`) and backend (`tests/test_server.py`). All tests pass.
* **Documentation:** Created and subsequently closed the backlog item.

No user interactions are required. Tested and visually verified via Playwright screenshot.

---
*PR created automatically by Jules for task [11991614956341168008](https://jules.google.com/task/11991614956341168008) started by @jjgroenendijk*