### PR TITLE
feat(ui): add inline audio player for downloaded audio files

### DIFF
--- a/docs/backlog/closed/001-audio-playback.md
+++ b/docs/backlog/closed/001-audio-playback.md
@@ -1,0 +1,10 @@
+# Inline Audio Playback
+
+## Description
+The SpotiFLAC web UI allows users to download audio files. Currently, users can download the files via a link, but there is no way to preview or play the audio directly in the browser.
+
+## Requirements
+- Add an inline audio player (`<audio controls>`) for audio files in the downloaded files list.
+- Supported extensions: `.flac`, `.mp3`, `.wav`, `.m4a`, `.ogg`.
+- The audio source should point to the correct file download API endpoint.
+- Include Playwright tests to verify the player is rendered correctly when an audio file is present in the job output.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -462,7 +462,15 @@ export function renderApp(root) {
                     const encodedJobId = encodeURIComponent(jobId);
                     const encodedFile = file.split('/').map(encodeURIComponent).join('/');
                     const fileName = file.split('/').pop();
-                    return `<li><a href="/api/jobs/${encodedJobId}/files/${encodedFile}" download="${escapeHtml(fileName)}" class="file-download-link">${escapeHtml(file)}</a></li>`;
+                    const fileUrl = `/api/jobs/${encodedJobId}/files/${encodedFile}`;
+
+                    let audioHtml = "";
+                    const lowerFile = file.toLowerCase();
+                    if (lowerFile.endsWith('.flac') || lowerFile.endsWith('.mp3') || lowerFile.endsWith('.wav') || lowerFile.endsWith('.m4a') || lowerFile.endsWith('.ogg')) {
+                        audioHtml = `<br><audio controls src="${fileUrl}" style="margin-top: 8px; max-width: 100%; height: 32px;"></audio>`;
+                    }
+
+                    return `<li style="margin-bottom: 12px;"><a href="${fileUrl}" download="${escapeHtml(fileName)}" class="file-download-link">${escapeHtml(file)}</a>${audioHtml}</li>`;
                 }).join("");
             } else {
                 filesList.innerHTML = "<li>No files found.</li>";

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -692,3 +692,60 @@ test('search input filters jobs by URL and ID', async ({ page }) => {
   await page.fill('#job-search-input', '');
   await expect(page.locator('.job-card')).toHaveCount(2);
 });
+
+test('renders audio player for audio files', async ({ page }) => {
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-audio',
+            url: 'https://open.spotify.com/track/audio1',
+            status: 'Completed',
+            created_at: new Date().toISOString(),
+            files: 2,
+            error_log: null
+          }
+        ])
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.route('/api/jobs/job-audio/files', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          files: ['song.flac', 'cover.jpg']
+        })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  const jobCard = page.locator('.job-card[data-job-id="job-audio"]');
+  await expect(jobCard).toBeVisible();
+
+  const viewFilesBtn = jobCard.locator('button.view-files-btn');
+  await expect(viewFilesBtn).toBeVisible();
+  await viewFilesBtn.click();
+
+  const filesContainer = page.locator('#files-container-job-audio');
+  await expect(filesContainer).toBeVisible();
+
+  // The flac file should have an audio element
+  const audioEl = filesContainer.locator('audio[src="/api/jobs/job-audio/files/song.flac"]');
+  await expect(audioEl).toBeVisible();
+
+  // The jpg file should not have an audio element
+  const nonAudioCount = await filesContainer.locator('audio[src="/api/jobs/job-audio/files/cover.jpg"]').count();
+  expect(nonAudioCount).toBe(0);
+});


### PR DESCRIPTION
This adds inline audio preview capabilities for the files downloaded by SpotiFLAC. It automatically detects common audio file extensions and appends a standard HTML5 audio player beneath the file link in the job files list view. The functionality has been thoroughly tested.

---
*PR created automatically by Jules for task [8594841203395586013](https://jules.google.com/task/8594841203395586013) started by @jjgroenendijk*