### PR TITLE
feat: Add "Type" filter to UI

### DIFF
--- a/docs/backlog/closed/filter-by-type.md
+++ b/docs/backlog/closed/filter-by-type.md
@@ -1,0 +1,10 @@
+# Filter Jobs by Type
+
+## Problem
+Users may want to easily find all playlists or albums they've downloaded without seeing individual tracks, but currently they can only filter by status or search by text.
+
+## Solution
+Add a "Type" filter dropdown next to the existing "Status" filter.
+1. The dropdown should have options: "All Types", "Track", "Album", "Playlist".
+2. The UI should filter the displayed jobs based on their URL type using the existing `classifySpotifyUrl` logic.
+3. Update Playwright tests to ensure filtering by type works.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -136,6 +136,12 @@ export function renderApp(root) {
           <h2>Recent jobs</h2>
           <div style="display: flex; gap: 8px; align-items: center;">
             <input type="text" id="job-search-input" placeholder="Search URL or ID..." class="job-search-input" aria-label="Search jobs" />
+            <select id="job-type-filter" class="job-status-filter clear-history-btn" aria-label="Filter jobs by type">
+              <option value="All Types">All Types</option>
+              <option value="Track">Track</option>
+              <option value="Album">Album</option>
+              <option value="Playlist">Playlist</option>
+            </select>
             <select id="job-status-filter" class="job-status-filter clear-history-btn" aria-label="Filter jobs by status">
               <option value="All">All</option>
               <option value="Queued">Queued</option>
@@ -165,6 +171,7 @@ export function renderApp(root) {
   const input = root.querySelector("#spotify-url");
   const feedback = root.querySelector("#queue-feedback");
   const jobList = root.querySelector("#job-list");
+  const typeFilter = root.querySelector("#job-type-filter");
   const statusFilter = root.querySelector("#job-status-filter");
   const searchInput = root.querySelector("#job-search-input");
 
@@ -231,8 +238,14 @@ export function renderApp(root) {
       // Sort jobs by newest first
       const sortedJobs = [...jobs].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
+      const selectedType = typeFilter ? typeFilter.value : "All Types";
+      let filteredJobs = selectedType === "All Types" ? sortedJobs : sortedJobs.filter(job => {
+        const jobType = classifySpotifyUrl(job.url);
+        return jobType.toLowerCase() === selectedType.toLowerCase();
+      });
+
       const selectedStatus = statusFilter ? statusFilter.value : "All";
-      let filteredJobs = selectedStatus === "All" ? sortedJobs : sortedJobs.filter(job => job.status === selectedStatus);
+      filteredJobs = selectedStatus === "All" ? filteredJobs : filteredJobs.filter(job => job.status === selectedStatus);
 
       const searchQuery = searchInput ? searchInput.value.trim().toLowerCase() : "";
       if (searchQuery) {
@@ -264,6 +277,10 @@ export function renderApp(root) {
       console.error(err);
       jobList.innerHTML = `<p class="error-state">Failed to load jobs.</p>`;
     }
+  }
+
+  if (typeFilter) {
+    typeFilter.addEventListener("change", fetchJobs);
   }
 
   if (statusFilter) {

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -749,3 +749,66 @@ test('renders audio player for audio files', async ({ page }) => {
   const nonAudioCount = await filesContainer.locator('audio[src="/api/jobs/job-audio/files/cover.jpg"]').count();
   expect(nonAudioCount).toBe(0);
 });
+
+test("filters jobs by type", async ({ page }) => {
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "101",
+            url: "https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 10,
+            error_log: null
+          },
+          {
+            id: "102",
+            url: "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC",
+            status: "Queued",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          },
+          {
+            id: "103",
+            url: "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+            status: "Running",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+        await route.continue();
+    }
+  });
+
+  await page.goto("http://127.0.0.1:3000");
+
+  // Initially, all jobs should be visible
+  await expect(page.locator('.job-card')).toHaveCount(3);
+
+  // Filter by Album
+  await page.selectOption('#job-type-filter', 'Album');
+  await expect(page.locator('.job-card')).toHaveCount(1);
+  await expect(page.locator('.job-card').first()).toContainText('album');
+
+  // Filter by Track
+  await page.selectOption('#job-type-filter', 'Track');
+  await expect(page.locator('.job-card')).toHaveCount(1);
+  await expect(page.locator('.job-card').first()).toContainText('track');
+
+  // Filter by Playlist
+  await page.selectOption('#job-type-filter', 'Playlist');
+  await expect(page.locator('.job-card')).toHaveCount(1);
+  await expect(page.locator('.job-card').first()).toContainText('playlist');
+
+  // Filter back to All Types
+  await page.selectOption('#job-type-filter', 'All Types');
+  await expect(page.locator('.job-card')).toHaveCount(3);
+});


### PR DESCRIPTION
I have added a "Type" filter dropdown to the UI next to the existing "Status" filter. This allows users to filter the displayed jobs based on their URL type (Track, Album, or Playlist). The logic uses the existing `classifySpotifyUrl` function. I have also added Playwright tests to verify the new filtering functionality and marked the backlog item as completed by moving it to the `closed/` directory. All tests (unit and e2e) pass.

---
*PR created automatically by Jules for task [18292854540945197533](https://jules.google.com/task/18292854540945197533) started by @jjgroenendijk*