### PR TITLE
feat: add clear completed button to web UI

### DIFF
--- a/docs/backlog/closed/clear-completed.md
+++ b/docs/backlog/closed/clear-completed.md
@@ -1,0 +1,13 @@
+# Clear Completed Jobs
+
+## Requirement
+Add a 'Clear completed' button to the web UI that allows users to easily clear all jobs with the 'Completed' status. This keeps the UI tidy and saves space without wiping out running or failed jobs that might still need attention.
+
+## Implementation Details
+
+### Backend
+- Add `DELETE /api/history/clear-completed` endpoint in `server.py` similar to the existing `clear-failed` logic. It will iterate through the job history, keep non-completed jobs, and clear the completed jobs along with their corresponding files and logs.
+
+### Frontend
+- Update `website/src/app.js` to render a new `<button>` for 'Clear completed'.
+- Add an event listener that prompts for confirmation and then calls the new endpoint via `DELETE`, triggering a UI refresh on success.

--- a/server.py
+++ b/server.py
@@ -436,6 +436,32 @@ async def clear_history():
 
     return {"status": "success", "cleared": len(cleared_jobs)}
 
+@app.delete("/api/history/clear-completed")
+async def clear_completed_history():
+    history = []
+    cleared_jobs = []
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        filtered_history = []
+        for job in history:
+            if job.get("status") == "Completed":
+                cleared_jobs.append(job["id"])
+            else:
+                filtered_history.append(job)
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(filtered_history, f, indent=2)
+
+    for job_id in cleared_jobs:
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        await asyncio.to_thread(_delete_job_files, job_id)
+
+    return {"status": "success", "cleared": len(cleared_jobs)}
+
 @app.delete("/api/history/clear-failed")
 async def clear_failed_history():
     history = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -87,6 +87,36 @@ def test_clear_failed_history():
     assert "Running" in statuses
     assert "Failed" not in statuses
 
+def test_clear_completed_history():
+    import json
+
+    # Write some dummy jobs directly to history file
+    dummy_history = [
+        {"id": "job-1", "url": "https://open.spotify.com/track/abc", "status": "Failed"},
+        {"id": "job-2", "url": "https://open.spotify.com/track/def", "status": "Completed"},
+        {"id": "job-3", "url": "https://open.spotify.com/track/ghi", "status": "Failed"},
+        {"id": "job-4", "url": "https://open.spotify.com/track/jkl", "status": "Running"},
+        {"id": "job-5", "url": "https://open.spotify.com/track/mno", "status": "Completed"}
+    ]
+    with open(HISTORY_FILE, "w") as f:
+        json.dump(dummy_history, f)
+
+    resp = client.delete("/api/history/clear-completed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert data["cleared"] == 2
+
+    resp = client.get("/api/jobs")
+    assert resp.status_code == 200
+    remaining_jobs = resp.json()
+
+    assert len(remaining_jobs) == 3
+    statuses = [j["status"] for j in remaining_jobs]
+    assert "Failed" in statuses
+    assert "Running" in statuses
+    assert "Completed" not in statuses
+
 def test_get_job_log(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -156,6 +156,7 @@ export function renderApp(root) {
               <input type="checkbox" id="auto-refresh-toggle" style="width: auto; min-height: auto; margin: 0; cursor: pointer;">
               Auto-refresh
             </label>
+            <button type="button" id="clear-completed-btn" class="clear-history-btn" style="border-color: rgba(16, 185, 129, 0.5); color: #10b981;">Clear completed</button>
             <button type="button" id="clear-failed-btn" class="clear-history-btn" style="border-color: rgba(220, 38, 38, 0.5); color: #dc2626;">Clear failed</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
           </div>
@@ -642,6 +643,28 @@ export function renderApp(root) {
       } finally {
         clearFailedBtn.disabled = false;
         clearFailedBtn.textContent = "Clear failed";
+      }
+    });
+  }
+
+  const clearCompletedBtn = root.querySelector("#clear-completed-btn");
+  if (clearCompletedBtn) {
+    clearCompletedBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to clear all completed jobs? This cannot be undone.")) {
+        return;
+      }
+      clearCompletedBtn.disabled = true;
+      clearCompletedBtn.textContent = "Clearing...";
+      try {
+        const response = await fetch("/api/history/clear-completed", { method: "DELETE" });
+        if (response.ok) {
+          fetchJobs();
+        }
+      } catch (err) {
+        console.error("Failed to clear completed jobs", err);
+      } finally {
+        clearCompletedBtn.disabled = false;
+        clearCompletedBtn.textContent = "Clear completed";
       }
     });
   }

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -173,6 +173,44 @@ describe("renderApp", () => {
     expect(global.localStorage.setItem).toHaveBeenCalledWith("theme", "dark");
   });
 
+  it("calls the clear-completed endpoint and refreshes when Clear completed is clicked", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    // Mock confirm to simulate user clicking "OK"
+    global.window.confirm = vi.fn(() => true);
+
+    const root = document.getElementById("root");
+
+    // Setup fetch mock to track calls
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementation((url, options) => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+    global.fetch = fetchMock;
+
+    renderApp(root);
+
+    const clearCompletedBtn = document.getElementById("clear-completed-btn");
+    expect(clearCompletedBtn).not.toBeNull();
+
+    clearCompletedBtn.click();
+
+    // Allow async handlers to complete
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(global.window.confirm).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith("/api/history/clear-completed", { method: "DELETE" });
+  });
+
   it("calls the clear-failed endpoint and refreshes when Clear failed is clicked", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",


### PR DESCRIPTION
This PR implements the new requirement to add a 'Clear completed' button to the web UI, allowing users to easily delete completed jobs and their associated files without affecting running or failed jobs. 

It introduces a new backend endpoint `/api/history/clear-completed` and hooks it up to a new frontend button. The changes are fully tested and verified both programmatically and visually.

---
*PR created automatically by Jules for task [9793635018996703681](https://jules.google.com/task/9793635018996703681) started by @jjgroenendijk*