### PR TITLE
feat: Add queue status summary to UI

### DIFF
--- a/docs/backlog/closed/queue-status-summary.md
+++ b/docs/backlog/closed/queue-status-summary.md
@@ -1,0 +1,14 @@
+# Queue Status Summary
+
+## Description
+As a user, I want to see a summary of the current job statuses (Queued, Running, Completed, Failed) at a glance above the job list, so I can quickly understand the system's overall state without manually counting items.
+
+## Acceptance Criteria
+- A summary text block (e.g., "Queued: X | Running: Y | Completed: Z | Failed: W") is displayed above the `.job-list` container.
+- The summary automatically updates whenever the job list is refreshed (e.g. periodically, or when a job finishes).
+- Missing statuses should show 0 or be omitted.
+
+## Technical Tasks
+- Modify `website/src/app.js` to add `#queue-status-summary` element in the DOM template.
+- Update the `fetchJobs` function in `app.js` to calculate the status counts and render them in the new element.
+- Add an automated UI test in `website/src/app.test.js` validating the display logic.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -161,6 +161,7 @@ export function renderApp(root) {
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
           </div>
         </div>
+        <div id="queue-status-summary" style="margin-bottom: 16px; font-size: 0.9rem; font-weight: 500; color: var(--text-primary);"></div>
         <div class="job-list" id="job-list">
           <!-- Jobs will be loaded here -->
         </div>
@@ -238,6 +239,16 @@ export function renderApp(root) {
 
       // Sort jobs by newest first
       const sortedJobs = [...jobs].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+      const statusCounts = jobs.reduce((acc, job) => {
+        acc[job.status] = (acc[job.status] || 0) + 1;
+        return acc;
+      }, { Queued: 0, Running: 0, Completed: 0, Failed: 0 });
+
+      const summaryElement = root.querySelector("#queue-status-summary");
+      if (summaryElement) {
+        summaryElement.textContent = `Queued: ${statusCounts.Queued} | Running: ${statusCounts.Running} | Completed: ${statusCounts.Completed} | Failed: ${statusCounts.Failed}`;
+      }
 
       const selectedType = typeFilter ? typeFilter.value : "All Types";
       let filteredJobs = selectedType === "All Types" ? sortedJobs : sortedJobs.filter(job => {

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -27,6 +27,43 @@ describe("classifySpotifyUrl", () => {
 });
 
 describe("renderApp", () => {
+  it("renders the queue status summary with correct counts", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([
+          { status: "Queued" },
+          { status: "Running" },
+          { status: "Running" },
+          { status: "Completed" },
+          { status: "Failed" },
+          { status: "Failed" },
+          { status: "Failed" }
+        ])
+      })
+    );
+
+    const cleanup = renderApp(root);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const summaryElement = document.getElementById("queue-status-summary");
+    expect(summaryElement).not.toBeNull();
+    expect(summaryElement.textContent).toBe("Queued: 1 | Running: 2 | Completed: 1 | Failed: 3");
+
+    cleanup();
+  });
+
   it("renders a job with file links properly formatted", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",


### PR DESCRIPTION
This PR implements the Queue Status Summary feature autonomously proposed and implemented according to Workflow Rule 4 in AGENTS.md. It adds a dynamically updating status counter (Queued, Running, Completed, Failed) above the job list in the UI, updates UI tests to verify the behavior, and closes the corresponding backlog item.

---
*PR created automatically by Jules for task [11620812831190259450](https://jules.google.com/task/11620812831190259450) started by @jjgroenendijk*