### PR TITLE
feat: add visual storage progress bar

### DIFF
--- a/docs/backlog/closed/001-storage-progress-bar.md
+++ b/docs/backlog/closed/001-storage-progress-bar.md
@@ -1,0 +1,9 @@
+# 001 - Visual Storage Progress Bar
+
+## Summary
+For self-hosted homelab deployments, keeping track of storage is critical. While the current UI displays the text "X free of Y", a visual progress bar in the storage panel provides a quick, scannable indication of capacity.
+
+## Tasks
+- Add HTML for a visual progress bar inside the `.storage-panel` in `website/src/app.js`.
+- Update `updateStorageUsage` to calculate the percentage and update the UI.
+- Add styling in `website/src/styles.css` matching the Apple Liquid Glass design.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -127,6 +127,9 @@ export function renderApp(root) {
         <aside class="storage-panel" aria-label="Storage status">
           <span>Data volume</span>
           <strong>/data</strong>
+          <div class="storage-progress-bar-bg" aria-hidden="true" style="margin-top: 8px; margin-bottom: 8px;">
+            <div class="storage-progress-bar-fill" id="storage-progress-fill" style="width: 0%;"></div>
+          </div>
           <p id="storage-usage-text">Job history, logs, and produced files will persist outside the container.</p>
         </aside>
       </section>
@@ -218,6 +221,17 @@ export function renderApp(root) {
         const textElement = root.querySelector("#storage-usage-text");
         if (textElement && data.free !== undefined && data.total !== undefined) {
           textElement.textContent = `${formatBytes(data.free)} free of ${formatBytes(data.total)}`;
+
+          const fillElement = root.querySelector("#storage-progress-fill");
+          if (fillElement && data.total > 0) {
+            const usedPercentage = ((data.total - data.free) / data.total) * 100;
+            fillElement.style.width = `${Math.min(100, Math.max(0, usedPercentage))}%`;
+            if (usedPercentage > 90) {
+              fillElement.classList.add("danger");
+            } else {
+              fillElement.classList.remove("danger");
+            }
+          }
         }
       }
     } catch (err) {

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -27,6 +27,84 @@ describe("classifySpotifyUrl", () => {
 });
 
 describe("renderApp", () => {
+  it("updates the storage progress bar correctly", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    global.fetch.mockImplementation((url) => {
+      if (url === "/api/system/storage") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ total: 1000, free: 100, used: 900 })
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+
+    const cleanup = renderApp(root);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const textElement = document.getElementById("storage-usage-text");
+    expect(textElement).not.toBeNull();
+    expect(textElement.textContent).toBe("100 B free of 1000 B");
+
+    const fillElement = document.getElementById("storage-progress-fill");
+    expect(fillElement).not.toBeNull();
+    // 900 / 1000 = 90%
+    expect(fillElement.style.width).toBe("90%");
+    // Wait, 90% is not > 90, so it shouldn't have danger class
+    expect(fillElement.classList.contains("danger")).toBe(false);
+
+    cleanup();
+  });
+
+  it("adds danger class to storage progress bar when over 90%", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    global.fetch.mockImplementation((url) => {
+      if (url === "/api/system/storage") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ total: 1000, free: 50, used: 950 })
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+
+    const cleanup = renderApp(root);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const fillElement = document.getElementById("storage-progress-fill");
+    expect(fillElement).not.toBeNull();
+    expect(fillElement.style.width).toBe("95%");
+    expect(fillElement.classList.contains("danger")).toBe(true);
+
+    cleanup();
+  });
+
   it("renders the queue status summary with correct counts", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -630,7 +630,8 @@ button:active {
 }
 
 /* Visual Progress Bar */
-.progress-bar-bg {
+.progress-bar-bg,
+.storage-progress-bar-bg {
   width: 100%;
   height: 8px;
   background: var(--glass-bg);
@@ -642,12 +643,18 @@ button:active {
   box-shadow: inset 0 1px 3px var(--glass-shadow);
 }
 
-.progress-bar-fill {
+.progress-bar-fill,
+.storage-progress-bar-fill {
   height: 100%;
   background: var(--btn-bg);
   border-radius: 999px;
-  transition: width 0.3s ease-out;
+  transition: width 0.3s ease-out, background-color 0.3s ease;
   box-shadow: 0 0 8px var(--input-shadow-focus);
+}
+
+.storage-progress-bar-fill.danger {
+  background: var(--error);
+  box-shadow: 0 0 8px var(--error);
 }
 
 /* File List Styles */


### PR DESCRIPTION
This commit introduces a new feature to the SpotiFLAC web UI: a visual progress bar indicating the storage capacity of the data volume.

Since no troubleshooting cases or open backlog items existed, a high-value requirement was proposed and tracked as `001-storage-progress-bar.md`. 

The change adds a progress bar to the `aside.storage-panel` component, styled using the established "Apple Liquid Glass" design system. The progress is calculated dynamically using the `data.free` and `data.total` properties returned from the existing `/api/system/storage` endpoint. If the storage usage exceeds 90%, the progress bar automatically applies a `danger` class (turning red).

Unit tests have been added to `app.test.js` to ensure the percentage calculation is accurate and the danger class toggles correctly. The frontend was verified visually via Playwright, and the full test suite passes. The relevant backlog item has been moved to the closed directory.

---
*PR created automatically by Jules for task [4667164194032439916](https://jules.google.com/task/4667164194032439916) started by @jjgroenendijk*