### PR TITLE
Rename Download ZIP button to Download All

### DIFF
--- a/docs/backlog/closed/download_all_button.md
+++ b/docs/backlog/closed/download_all_button.md
@@ -1,0 +1,11 @@
+# Add "Download All" button to SpotiFLAC web UI
+
+The user needs a way to download all files from a completed job as a single ZIP archive.
+Currently, there is a `/api/jobs/{job_id}/download` endpoint, but it needs to be integrated into the UI.
+
+## Requirements:
+1.  **UI Component:** Add a "Download All" button to the job details view in the frontend.
+    -   The button should be visible only for jobs with a status of "Completed".
+    -   The button should match the "Apple Liquid Glass" style guide.
+    -   Clicking the button should trigger a download of the ZIP archive from `/api/jobs/{job_id}/download`.
+2.  **Testing:** Add a Playwright test to verify the functionality of the new button.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -43,7 +43,7 @@ function renderJob(job) {
   const deleteBtnHtml = canDelete ? `<button type="button" class="delete-job-btn" data-job-id="${escapeHtml(job.id)}">Delete</button>` : "";
   const viewLogsBtnHtml = `<button type="button" class="view-logs-btn" data-job-id="${escapeHtml(job.id)}">View Logs</button>`;
   const viewFilesBtnHtml = job.status === "Completed" ? `<button type="button" class="view-files-btn" data-job-id="${escapeHtml(job.id)}">View Files</button>` : "";
-  const downloadZipBtnHtml = job.status === "Completed" ? `<a href="/api/jobs/${escapeHtml(job.id)}/download" download class="download-zip-btn view-files-btn">Download ZIP</a>` : "";
+  const downloadZipBtnHtml = job.status === "Completed" ? `<a href="/api/jobs/${escapeHtml(job.id)}/download" download class="download-zip-btn view-files-btn">Download All</a>` : "";
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
   const urlType = classifySpotifyUrl(job.url);

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -495,11 +495,45 @@ test('displays Download ZIP link for completed jobs', async ({ page }) => {
   // Find the Download ZIP link
   const downloadLink = jobCard.locator('.download-zip-btn');
   await expect(downloadLink).toBeVisible();
-  await expect(downloadLink).toHaveText('Download ZIP');
+  await expect(downloadLink).toHaveText('Download All');
 
   // Verify the href attribute
   await expect(downloadLink).toHaveAttribute('href', '/api/jobs/123/download');
   await expect(downloadLink).toHaveAttribute('download', '');
+});
+
+test('displays Download All button on job card when completed', async ({ page }) => {
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-12345',
+            url: 'https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX',
+            status: 'Completed',
+            created_at: new Date().toISOString(),
+            files: 10,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  const jobCard = page.locator('.job-card[data-job-id="job-12345"]');
+  await expect(jobCard).toBeVisible();
+
+  const downloadAllBtn = jobCard.locator('a.download-zip-btn');
+  await expect(downloadAllBtn).toBeVisible();
+  await expect(downloadAllBtn).toHaveText('Download All');
+  await expect(downloadAllBtn).toHaveAttribute('href', '/api/jobs/job-12345/download');
+  await expect(downloadAllBtn).toHaveAttribute('download', '');
 });
 
 test('displays Download all completed button when completed jobs exist', async ({ page }) => {


### PR DESCRIPTION
I have successfully completed the backlog task by renaming the `Download ZIP` button to `Download All` in the frontend UI (`app.js`). I have also added a dedicated Playwright test case to verify that the `Download All` button properly links to the correct endpoint. Tests and build step passed locally, and the updated frontend screenshot looks accurate.

---
*PR created automatically by Jules for task [9286596177287605916](https://jules.google.com/task/9286596177287605916) started by @jjgroenendijk*