### PR TITLE
feat: add clear cancelled jobs functionality

### DIFF
--- a/docs/backlog/closed/clear-cancelled-jobs.md
+++ b/docs/backlog/closed/clear-cancelled-jobs.md
@@ -1,0 +1,12 @@
+# Clear Cancelled Jobs
+
+## Context
+The SpotiFLAC web UI allows users to clear completed and failed jobs from their history. However, there is currently no way to quickly clear cancelled jobs from the history other than clicking delete on each one manually or clearing the entire history.
+
+## Requirement
+Add a "Clear cancelled" button to the job list actions that allows the user to clear all cancelled jobs from the history at once.
+
+## Acceptance Criteria
+1. A `DELETE /api/history/clear-cancelled` endpoint is available on the backend to remove only jobs with status "Cancelled".
+2. The UI has a "Clear cancelled" button alongside the existing "Clear completed" and "Clear failed" buttons.
+3. Clicking the button calls the endpoint, clears cancelled jobs, and refreshes the job list.

--- a/server.py
+++ b/server.py
@@ -436,6 +436,32 @@ async def clear_history():
 
     return {"status": "success", "cleared": len(cleared_jobs)}
 
+@app.delete("/api/history/clear-cancelled")
+async def clear_cancelled_history():
+    history = []
+    cleared_jobs = []
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        filtered_history = []
+        for job in history:
+            if job.get("status") == "Cancelled":
+                cleared_jobs.append(job["id"])
+            else:
+                filtered_history.append(job)
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(filtered_history, f, indent=2)
+
+    for job_id in cleared_jobs:
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        await asyncio.to_thread(_delete_job_files, job_id)
+
+    return {"status": "success", "cleared": len(cleared_jobs)}
+
 @app.delete("/api/history/clear-completed")
 async def clear_completed_history():
     history = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -87,6 +87,35 @@ def test_clear_failed_history():
     assert "Running" in statuses
     assert "Failed" not in statuses
 
+def test_clear_cancelled_history():
+    import json
+
+    # Write some dummy jobs directly to history file
+    dummy_history = [
+        {"id": "job-1", "url": "https://open.spotify.com/track/abc", "status": "Cancelled"},
+        {"id": "job-2", "url": "https://open.spotify.com/track/def", "status": "Completed"},
+        {"id": "job-3", "url": "https://open.spotify.com/track/ghi", "status": "Cancelled"},
+        {"id": "job-4", "url": "https://open.spotify.com/track/jkl", "status": "Running"}
+    ]
+    with open(HISTORY_FILE, "w") as f:
+        json.dump(dummy_history, f)
+
+    resp = client.delete("/api/history/clear-cancelled")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert data["cleared"] == 2
+
+    resp = client.get("/api/jobs")
+    assert resp.status_code == 200
+    remaining_jobs = resp.json()
+
+    assert len(remaining_jobs) == 2
+    statuses = [j["status"] for j in remaining_jobs]
+    assert "Completed" in statuses
+    assert "Running" in statuses
+    assert "Cancelled" not in statuses
+
 def test_clear_completed_history():
     import json
 

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -162,6 +162,7 @@ export function renderApp(root) {
             <button type="button" id="clear-completed-btn" class="clear-history-btn" style="border-color: rgba(16, 185, 129, 0.5); color: #10b981;">Clear completed</button>
             <button type="button" id="retry-failed-btn" class="clear-history-btn" style="border-color: rgba(234, 179, 8, 0.5); color: #eab308;">Retry failed</button>
             <button type="button" id="clear-failed-btn" class="clear-history-btn" style="border-color: rgba(220, 38, 38, 0.5); color: #dc2626;">Clear failed</button>
+            <button type="button" id="clear-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Clear cancelled</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
           </div>
         </div>
@@ -625,6 +626,30 @@ export function renderApp(root) {
       } finally {
         refreshJobsBtn.disabled = false;
         refreshJobsBtn.textContent = "Refresh jobs";
+      }
+    });
+  }
+
+  const clearCancelledBtn = root.querySelector("#clear-cancelled-btn");
+  if (clearCancelledBtn) {
+    clearCancelledBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to clear all cancelled jobs? This cannot be undone.")) {
+        return;
+      }
+      clearCancelledBtn.disabled = true;
+      clearCancelledBtn.textContent = "Clearing...";
+      try {
+        const response = await fetch("/api/history/clear-cancelled", { method: "DELETE" });
+        if (response.ok) {
+          fetchJobs();
+        } else {
+          console.error("Failed to clear cancelled history");
+        }
+      } catch (error) {
+        console.error("Error clearing cancelled history:", error);
+      } finally {
+        clearCancelledBtn.disabled = false;
+        clearCancelledBtn.textContent = "Clear cancelled";
       }
     });
   }

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -235,7 +235,7 @@ test("shows cancel button for queued job and handles click", async ({ page }) =>
 
   await page.goto("/");
 
-  const cancelBtn = page.getByRole("button", { name: "Cancel" });
+  const cancelBtn = page.getByRole("button", { name: "Cancel", exact: true });
   await expect(cancelBtn).toBeVisible();
 
   await cancelBtn.click();


### PR DESCRIPTION
Adds a new feature to clear only the cancelled jobs from history. This fills a gap in the UI functionality which allowed clearing failed and completed jobs, but required manual deletion for cancelled jobs. Backend includes a new endpoint, matching the pattern of other clear commands. Frontend includes a new corresponding button. Added a new backend test for this functionality. Fixed an existing strict mode Playwright test failure along the way.

---
*PR created automatically by Jules for task [14875541716729319801](https://jules.google.com/task/14875541716729319801) started by @jjgroenendijk*