### PR TITLE
feat: implement job history sorting

### DIFF
--- a/docs/backlog/closed/sort-history.md
+++ b/docs/backlog/closed/sort-history.md
@@ -1,0 +1,11 @@
+# Sort History
+
+## Requirement
+Add a sorting dropdown to the history view to allow sorting jobs by creation date (newest first, oldest first).
+Currently, jobs are always displayed "newest first" by hardcoding `[...jobs].sort((a, b) => new Date(b.created_at) - new Date(a.created_at))`.
+
+## Scope
+- Add a `<select>` element to the UI in `website/src/app.js`.
+- Modify the `fetchJobs` function in `website/src/app.js` to read the `<select>` value and sort the `sortedJobs` array accordingly.
+- Add event listeners so `fetchJobs` is called when the sort selection changes.
+- Add Playwright tests to ensure the jobs are ordered correctly when "Oldest First" is selected.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -139,6 +139,10 @@ export function renderApp(root) {
           <h2>Recent jobs</h2>
           <div style="display: flex; gap: 8px; align-items: center;">
             <input type="text" id="job-search-input" placeholder="Search URL or ID..." class="job-search-input" aria-label="Search jobs" />
+            <select id="job-sort-select" class="job-status-filter clear-history-btn" aria-label="Sort jobs">
+              <option value="newest">Newest First</option>
+              <option value="oldest">Oldest First</option>
+            </select>
             <select id="job-type-filter" class="job-status-filter clear-history-btn" aria-label="Filter jobs by type">
               <option value="All Types">All Types</option>
               <option value="Track">Track</option>
@@ -181,6 +185,7 @@ export function renderApp(root) {
   const typeFilter = root.querySelector("#job-type-filter");
   const statusFilter = root.querySelector("#job-status-filter");
   const searchInput = root.querySelector("#job-search-input");
+  const sortSelect = root.querySelector("#job-sort-select");
 
   async function updateProgress(jobId) {
     const container = root.querySelector(`#progress-container-${jobId}`);
@@ -253,8 +258,14 @@ export function renderApp(root) {
         downloadAllBtn.style.display = hasCompleted ? "inline-flex" : "none";
       }
 
-      // Sort jobs by newest first
-      const sortedJobs = [...jobs].sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      // Sort jobs
+      const sortOrder = sortSelect ? sortSelect.value : "newest";
+      const sortedJobs = [...jobs].sort((a, b) => {
+        if (sortOrder === "oldest") {
+          return new Date(a.created_at) - new Date(b.created_at);
+        }
+        return new Date(b.created_at) - new Date(a.created_at);
+      });
 
       const statusCounts = jobs.reduce((acc, job) => {
         acc[job.status] = (acc[job.status] || 0) + 1;
@@ -313,6 +324,10 @@ export function renderApp(root) {
 
   if (statusFilter) {
     statusFilter.addEventListener("change", fetchJobs);
+  }
+
+  if (sortSelect) {
+    sortSelect.addEventListener("change", fetchJobs);
   }
 
   if (searchInput) {

--- a/website/tests/sort.spec.js
+++ b/website/tests/sort.spec.js
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  // Mock the /api/jobs GET request to return two jobs with different creation dates
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "older-job",
+            url: "https://open.spotify.com/album/older",
+            status: "Completed",
+            created_at: new Date(Date.now() - 100000).toISOString(),
+            files: 10,
+            error_log: null
+          },
+          {
+            id: "newer-job",
+            url: "https://open.spotify.com/album/newer",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 10,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+        await route.continue();
+    }
+  });
+
+  await page.route("/api/system/storage", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ total: 100, used: 10, free: 90 })
+    });
+  });
+});
+
+test("Sorts jobs by newest and oldest correctly", async ({ page }) => {
+  await page.goto("/");
+
+  // By default, it should be sorted newest first.
+  const jobsBeforeSort = page.locator(".job-card");
+  await expect(jobsBeforeSort).toHaveCount(2);
+
+  const firstJobIdNewest = await jobsBeforeSort.nth(0).getAttribute("data-job-id");
+  const secondJobIdNewest = await jobsBeforeSort.nth(1).getAttribute("data-job-id");
+  expect(firstJobIdNewest).toBe("newer-job");
+  expect(secondJobIdNewest).toBe("older-job");
+
+  // Select Oldest First
+  await page.locator("#job-sort-select").selectOption("oldest");
+
+  // Wait for the re-render (which calls fetchJobs)
+  // We can just wait for the DOM to update by checking the first job's ID
+  await expect(page.locator(".job-card").nth(0)).toHaveAttribute("data-job-id", "older-job");
+
+  // It should now be sorted oldest first.
+  const firstJobIdOldest = await page.locator(".job-card").nth(0).getAttribute("data-job-id");
+  const secondJobIdOldest = await page.locator(".job-card").nth(1).getAttribute("data-job-id");
+
+  expect(firstJobIdOldest).toBe("older-job");
+  expect(secondJobIdOldest).toBe("newer-job");
+});


### PR DESCRIPTION
Implement job history sorting functionality to allow users to view jobs starting with newest or oldest first. Includes UI changes, frontend logic, Playwright tests, and backlog tracking.

---
*PR created automatically by Jules for task [14367139989745099132](https://jules.google.com/task/14367139989745099132) started by @jjgroenendijk*