### PR TITLE
feat: add export history JSON functionality

### DIFF
--- a/docs/backlog/closed/020-export-history-json.md
+++ b/docs/backlog/closed/020-export-history-json.md
@@ -1,0 +1,9 @@
+# Export History as JSON
+
+## Objective
+Provide users with a way to export their entire job history as a JSON file from the web UI. This is a high-value feature for users who self-host and want to back up or migrate their downloaded media history.
+
+## Scope
+- Add a new endpoint `GET /api/history/export` in `server.py` that returns the `history.json` content as a downloadable `.json` file.
+- Add an "Export History JSON" button to the frontend UI in `website/src/app.js` (e.g., next to the clear history buttons).
+- Write a Playwright/unit test in `website/src/app.test.js` to ensure the button is rendered and has the correct `href`.

--- a/server.py
+++ b/server.py
@@ -404,6 +404,21 @@ def download_all_completed_jobs(background_tasks: BackgroundTasks):
         filename="SpotiFLAC-all-completed.zip"
     )
 
+@app.get("/api/history/export")
+async def export_history_json():
+    if not HISTORY_FILE.exists():
+        # Return an empty JSON array if history doesn't exist
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            content=[],
+            headers={"Content-Disposition": 'attachment; filename="SpotiFLAC-history.json"'}
+        )
+    return FileResponse(
+        path=HISTORY_FILE,
+        media_type="application/json",
+        filename="SpotiFLAC-history.json"
+    )
+
 def _delete_job_files(job_id: str):
     import shutil
     job_dir = DATA_DIR / job_id

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -169,6 +169,7 @@ export function renderApp(root) {
             <button type="button" id="clear-running-btn" class="clear-history-btn" style="border-color: rgba(59, 130, 246, 0.5); color: #3b82f6;">Clear running</button>
             <button type="button" id="clear-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Clear cancelled</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
+            <a href="/api/history/export" id="export-history-btn" class="clear-history-btn" download style="text-decoration: none; border-color: rgba(139, 92, 246, 0.5); color: #8b5cf6;">Export JSON</a>
           </div>
         </div>
         <div id="queue-status-summary" style="margin-bottom: 16px; font-size: 0.9rem; font-weight: 500; color: var(--text-primary);"></div>

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -27,6 +27,28 @@ describe("classifySpotifyUrl", () => {
 });
 
 describe("renderApp", () => {
+  it("renders the Export JSON button correctly", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    const cleanup = renderApp(root);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const exportBtn = document.getElementById("export-history-btn");
+    expect(exportBtn).not.toBeNull();
+    expect(exportBtn.getAttribute("href")).toBe("/api/history/export");
+
+    cleanup();
+  });
+
   it("updates the storage progress bar correctly", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",


### PR DESCRIPTION
This pull request implements the capability for users to export their entire job history as a JSON file, addressing the requirements set out in the open backlog. 

Changes include:
- A new endpoint `GET /api/history/export` in `server.py` that serves the application's `history.json`.
- A frontend update adding an "Export JSON" button linked to this endpoint, matching the design of the other clear history actions.
- Tests added in `website/src/app.test.js` to assert the rendering of this new button.
- Updates to backlog documentation, moving the `020-export-history-json.md` from `docs/backlog/open` to `docs/backlog/closed`.

---
*PR created automatically by Jules for task [11977705371540151290](https://jules.google.com/task/11977705371540151290) started by @jjgroenendijk*