### PR TITLE
feat: Add Retry Cancelled Jobs bulk retry button

### DIFF
--- a/docs/backlog/closed/021-retry-cancelled-jobs.md
+++ b/docs/backlog/closed/021-retry-cancelled-jobs.md
@@ -1,0 +1,13 @@
+# Retry Cancelled Jobs
+
+## Requirement
+Add a "Retry cancelled" button to the job list header. This button should queue up new jobs for every currently cancelled job, saving the user from clicking "Retry" on each individual cancelled job manually.
+
+## Implementation Plan
+1. Add a `<button type="button" id="retry-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Retry cancelled</button>` in `website/src/app.js` next to "Clear cancelled".
+2. Attach an event listener to the button that:
+   - Fetches the list of all jobs from `/api/jobs`.
+   - Filters the jobs to only those with `status === "Cancelled"`.
+   - Calls the `POST /api/jobs` endpoint for each cancelled job's URL.
+   - Refreshes the job list.
+3. Write a Playwright test to verify the functionality.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -167,6 +167,7 @@ export function renderApp(root) {
             <button type="button" id="retry-failed-btn" class="clear-history-btn" style="border-color: rgba(234, 179, 8, 0.5); color: #eab308;">Retry failed</button>
             <button type="button" id="clear-failed-btn" class="clear-history-btn" style="border-color: rgba(220, 38, 38, 0.5); color: #dc2626;">Clear failed</button>
             <button type="button" id="clear-running-btn" class="clear-history-btn" style="border-color: rgba(59, 130, 246, 0.5); color: #3b82f6;">Clear running</button>
+            <button type="button" id="retry-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Retry cancelled</button>
             <button type="button" id="clear-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Clear cancelled</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
             <a href="/api/history/export" id="export-history-btn" class="clear-history-btn" download style="text-decoration: none; border-color: rgba(139, 92, 246, 0.5); color: #8b5cf6;">Export JSON</a>
@@ -744,6 +745,37 @@ export function renderApp(root) {
       } finally {
         retryFailedBtn.disabled = false;
         retryFailedBtn.textContent = "Retry failed";
+      }
+    });
+  }
+
+  const retryCancelledBtn = root.querySelector("#retry-cancelled-btn");
+  if (retryCancelledBtn) {
+    retryCancelledBtn.addEventListener("click", async () => {
+      retryCancelledBtn.disabled = true;
+      retryCancelledBtn.textContent = "Retrying...";
+      try {
+        const jobsResponse = await fetch("/api/jobs");
+        if (jobsResponse.ok) {
+          const jobs = await jobsResponse.json();
+          const cancelledJobs = jobs.filter(job => job.status === "Cancelled");
+
+          const retryRequests = cancelledJobs.map(job =>
+            fetch("/api/jobs", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ url: job.url })
+            })
+          );
+
+          await Promise.allSettled(retryRequests);
+          fetchJobs();
+        }
+      } catch (err) {
+        console.error("Failed to retry cancelled jobs", err);
+      } finally {
+        retryCancelledBtn.disabled = false;
+        retryCancelledBtn.textContent = "Retry cancelled";
       }
     });
   }

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -348,6 +348,61 @@ describe("renderApp", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/history/clear-completed", { method: "DELETE" });
   });
 
+  it("calls the retry all cancelled jobs API when Retry cancelled is clicked", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementation((url, options) => {
+      if (url === "/api/jobs" && (!options || options.method === "GET")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            { id: "1", url: "https://open.spotify.com/track/1", status: "Cancelled" },
+            { id: "2", url: "https://open.spotify.com/track/2", status: "Completed" }
+          ])
+        });
+      }
+      if (url === "/api/jobs" && options && options.method === "POST") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+    global.fetch = fetchMock;
+
+    renderApp(root);
+
+    // Initial fetch from renderApp
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const retryCancelledBtn = document.getElementById("retry-cancelled-btn");
+    expect(retryCancelledBtn).not.toBeNull();
+
+    retryCancelledBtn.click();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/jobs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://open.spotify.com/track/1" })
+    });
+
+    // Should not retry the completed job
+    const calls = fetchMock.mock.calls.filter(call => call[0] === "/api/jobs" && call[1] && call[1].method === "POST");
+    expect(calls.length).toBe(1);
+  });
+
   it("calls the clear-failed endpoint and refreshes when Clear failed is clicked", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -592,6 +592,7 @@ test('displays Download All button on job card when completed', async ({ page })
   await expect(downloadAllBtn).toHaveAttribute('download', '');
 });
 
+
 test('displays Download all completed button when completed jobs exist', async ({ page }) => {
   // Use the mocked API route to provide a completed job
   await page.route('/api/jobs', async (route) => {
@@ -903,6 +904,57 @@ test("filters jobs by type", async ({ page }) => {
   await expect(page.locator('.job-card')).toHaveCount(3);
 });
 
+test('retry all cancelled jobs', async ({ page }) => {
+  let retryCalled = false;
+  let retriedUrl = '';
+
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-cancelled',
+            url: 'https://open.spotify.com/track/cancelled-track',
+            status: 'Cancelled',
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ])
+      });
+    } else if (route.request().method() === 'POST') {
+      retryCalled = true;
+      const postData = JSON.parse(route.request().postData() || '{}');
+      retriedUrl = postData.url;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ job_id: 'new-job-id' })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  // Wait for the job card to load
+  await expect(page.locator('.job-card')).toHaveCount(1);
+
+  const retryCancelledBtn = page.locator('#retry-cancelled-btn');
+  await expect(retryCancelledBtn).toBeVisible();
+
+  await retryCancelledBtn.click();
+
+  // Give it a moment to call the API
+  await page.waitForTimeout(500);
+
+  expect(retryCalled).toBe(true);
+  expect(retriedUrl).toBe('https://open.spotify.com/track/cancelled-track');
+});
+
 test('can retry all failed jobs', async ({ page }) => {
   let retryCalled = false;
   let retriedUrl = '';
@@ -953,6 +1005,7 @@ test('can retry all failed jobs', async ({ page }) => {
   expect(retryCalled).toBe(true);
   expect(retriedUrl).toBe('https://open.spotify.com/track/failed-track');
 });
+
 
 test('can queue multiple comma-separated URLs', async ({ page }) => {
   let queuedUrls = [];


### PR DESCRIPTION
This PR implements the requested "Retry cancelled" jobs button.

It queries all current jobs, filters for ones with a `status` of `"Cancelled"`, and executes parallel retry requests in bulk for their respective URLs. The button accurately reflects a `Retrying...` state to prevent duplicate user submissions during execution. Unit tests (Vitest) and e2e testing (Playwright) have been fully developed to cover the new functionality.

---
*PR created automatically by Jules for task [10683995049091226982](https://jules.google.com/task/10683995049091226982) started by @jjgroenendijk*