### PR TITLE
feat: add "clear queued" button to manage job queue

### DIFF
--- a/docs/backlog/closed/022-clear-queued-jobs.md
+++ b/docs/backlog/closed/022-clear-queued-jobs.md
@@ -1,0 +1,14 @@
+# Requirement: Clear Queued Jobs
+
+**Value:** Medium
+**Description:** Users should be able to clear all currently queued jobs to manage the job queue.
+
+**Tasks:**
+1. Add a "Clear queued" button in the frontend (e.g., next to the clear running/history buttons).
+2. Wire it up in the frontend to call a new `DELETE /api/history/clear-queued` endpoint.
+3. Implement the `DELETE /api/history/clear-queued` endpoint in the backend (`server.py`) which updates the status to cancelled for queued jobs or removes them.
+4. Write Playwright test to verify this UI.
+
+**Acceptance Criteria:**
+- The new button allows clearing jobs that are specifically in the `Queued` state.
+- Playwright tests pass.

--- a/server.py
+++ b/server.py
@@ -484,6 +484,32 @@ async def clear_running_history():
 
     return {"status": "success", "cleared": len(cleared_jobs)}
 
+@app.delete("/api/history/clear-queued")
+async def clear_queued_history():
+    history = []
+    cleared_jobs = []
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        filtered_history = []
+        for job in history:
+            if job.get("status") == "Queued":
+                cleared_jobs.append(job["id"])
+            else:
+                filtered_history.append(job)
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(filtered_history, f, indent=2)
+
+    for job_id in cleared_jobs:
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        await asyncio.to_thread(_delete_job_files, job_id)
+
+    return {"status": "success", "cleared": len(cleared_jobs)}
+
 @app.delete("/api/history/clear-cancelled")
 async def clear_cancelled_history():
     history = []

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -169,6 +169,7 @@ export function renderApp(root) {
             <button type="button" id="clear-running-btn" class="clear-history-btn" style="border-color: rgba(59, 130, 246, 0.5); color: #3b82f6;">Clear running</button>
             <button type="button" id="retry-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Retry cancelled</button>
             <button type="button" id="clear-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Clear cancelled</button>
+            <button type="button" id="clear-queued-btn" class="clear-history-btn" style="border-color: rgba(249, 115, 22, 0.5); color: #f97316;">Clear queued</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
             <a href="/api/history/export" id="export-history-btn" class="clear-history-btn" download style="text-decoration: none; border-color: rgba(139, 92, 246, 0.5); color: #8b5cf6;">Export JSON</a>
           </div>
@@ -692,6 +693,30 @@ export function renderApp(root) {
       } finally {
         clearCancelledBtn.disabled = false;
         clearCancelledBtn.textContent = "Clear cancelled";
+      }
+    });
+  }
+
+  const clearQueuedBtn = root.querySelector("#clear-queued-btn");
+  if (clearQueuedBtn) {
+    clearQueuedBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to clear all queued jobs? This cannot be undone.")) {
+        return;
+      }
+      clearQueuedBtn.disabled = true;
+      clearQueuedBtn.textContent = "Clearing...";
+      try {
+        const response = await fetch("/api/history/clear-queued", { method: "DELETE" });
+        if (response.ok) {
+          fetchJobs();
+        } else {
+          console.error("Failed to clear queued history");
+        }
+      } catch (error) {
+        console.error("Error clearing queued history:", error);
+      } finally {
+        clearQueuedBtn.disabled = false;
+        clearQueuedBtn.textContent = "Clear queued";
       }
     });
   }

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -56,7 +56,7 @@ test("validates supported Spotify URLs and queues job", async ({ page }) => {
   await page.goto("/");
 
   await page.getByLabel("Spotify URLs").fill("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M");
-  await page.getByRole("button", { name: "Queue" }).click();
+  await page.getByRole("button", { name: "Queue", exact: true }).click();
 
   await expect(page.getByText("Successfully queued 1 job.")).toBeVisible();
 });
@@ -87,7 +87,7 @@ test("validates and queues multiple Spotify URLs", async ({ page }) => {
 
   const urls = "https://open.spotify.com/track/123,https://open.spotify.com/album/456,  https://open.spotify.com/playlist/789  ";
   await page.getByLabel("Spotify URLs").fill(urls);
-  await page.getByRole("button", { name: "Queue" }).click();
+  await page.getByRole("button", { name: "Queue", exact: true }).click();
 
   await expect(page.getByText("Successfully queued 3 jobs.")).toBeVisible();
 
@@ -357,6 +357,50 @@ test("can refresh job list", async ({ page }) => {
 
   // Verify that a network request was made
   expect(fetchJobsCalledCount).toBeGreaterThan(0);
+});
+
+test("can clear queued jobs", async ({ page }) => {
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          { id: "test-queued-job-1", status: "Queued", url: "https://open.spotify.com/track/queued1" },
+          { id: "test-completed-job-1", status: "Completed", url: "https://open.spotify.com/track/completed1" }
+        ])
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  let clearQueuedCalled = false;
+  await page.route("/api/history/clear-queued", async (route) => {
+    if (route.request().method() === "DELETE") {
+      clearQueuedCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "success", cleared: 1 })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  const clearQueuedBtn = page.getByRole("button", { name: "Clear queued" });
+  await expect(clearQueuedBtn).toBeVisible();
+
+  page.once("dialog", dialog => dialog.accept());
+
+  const requestPromise = page.waitForRequest("/api/history/clear-queued");
+  await clearQueuedBtn.click();
+  await requestPromise;
+
+  expect(clearQueuedCalled).toBe(true);
 });
 
 test("can clear running jobs", async ({ page }) => {


### PR DESCRIPTION
Adds functionality to manage the job queue by clearing all currently "Queued" jobs via a new frontend button and a corresponding backend API.
- Re-uses styling and functionality patterns from other "Clear" buttons.
- Updates tests to be resilient to strict mode violations (`exact: true` for the original `Queue` button)
- Included complete pre-commit suite including unit tests, e2e playwright scripts, linting and frontend verification workflow.

---
*PR created automatically by Jules for task [16883874358642394177](https://jules.google.com/task/16883874358642394177) started by @jjgroenendijk*