### PR TITLE
Add `completed_at` timestamp to job response

### DIFF
--- a/docs/backlog/closed/show-completed-at.md
+++ b/docs/backlog/closed/show-completed-at.md
@@ -1,0 +1,10 @@
+# Add "Completed At" timestamp to jobs
+
+When a job reaches a final state (Completed, Failed, or Cancelled), the backend should record a `completed_at` timestamp.
+The web UI should display this timestamp on the job card, showing when the job was finished, similarly to how it displays the creation time.
+
+Requirements:
+- Add `completed_at` field to `JobResponse` in `server.py` and job history logic.
+- Update `app.js` to render `completed_at` if available on the job card.
+- Add unit tests for the backend to verify the timestamp is set and preserved.
+- Ensure the UI handles missing `completed_at` gracefully (for older jobs).

--- a/server.py
+++ b/server.py
@@ -55,6 +55,7 @@ class JobResponse(BaseModel):
     created_at: str
     error_log: Optional[str] = None
     files: Optional[int] = 0
+    completed_at: Optional[str] = None
 
 
 async def read_history() -> List[Dict]:
@@ -87,6 +88,8 @@ async def update_job_status(job_id: str, status: str, error_log: Optional[str] =
                 job["error_log"] = error_log
             if files is not None:
                 job["files"] = files
+            if status in ("Completed", "Failed", "Cancelled"):
+                job["completed_at"] = datetime.now(timezone.utc).isoformat()
             break
     await write_history(history)
 
@@ -605,6 +608,7 @@ async def cancel_job(job_id: str):
                 job_found = True
                 if job["status"] in ["Queued", "Running"]:
                     job["status"] = "Cancelled"
+                    job["completed_at"] = datetime.now(timezone.utc).isoformat()
                     new_history.append(job)
                 else:
                     # Actually delete it from history

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,6 +28,7 @@ def test_create_job(mock_run):
     assert "id" in data
     assert data["url"] == "https://open.spotify.com/track/123"
     assert data["status"] == "Queued"
+    assert "completed_at" not in data or data["completed_at"] is None
 
     # Verify it was added to history
     response = client.get("/api/jobs")
@@ -35,6 +36,7 @@ def test_create_job(mock_run):
     jobs = response.json()
     assert len(jobs) == 1
     assert jobs[0]["id"] == data["id"]
+    assert "completed_at" not in jobs[0] or jobs[0]["completed_at"] is None
 
 @patch('server.run_spotiflac')
 def test_cancel_job(mock_run):
@@ -53,6 +55,8 @@ def test_cancel_job(mock_run):
     jobs = response.json()
     assert jobs[0]["id"] == job_id
     assert jobs[0]["status"] == "Cancelled"
+    assert "completed_at" in jobs[0]
+    assert isinstance(jobs[0]["completed_at"], str)
 
 def test_cancel_nonexistent_job():
     response = client.delete("/api/jobs/not-a-real-id")

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -47,6 +47,7 @@ function renderJob(job) {
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
   const urlType = classifySpotifyUrl(job.url);
+  const completedAtHtml = job.completed_at ? `<p class="job-source" style="margin-top: 4px;">Completed: ${new Date(job.completed_at).toLocaleString()}</p>` : "";
 
   return `
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">
@@ -57,6 +58,7 @@ function renderJob(job) {
           <span class="url-type-badge" style="font-size: 0.75rem; background: rgba(255,255,255,0.2); padding: 2px 6px; border-radius: 4px; margin-left: 8px; text-transform: capitalize; vertical-align: middle;">${escapeHtml(urlType)}</span>
         </p>
         <p class="job-source">Started: ${new Date(job.created_at).toLocaleString()}</p>
+        ${completedAtHtml}
       </div>
       <div class="job-meta">
         <span>${escapeHtml(job.status)}</span>


### PR DESCRIPTION
This PR introduces the `completed_at` timestamp for all completed, failed, or cancelled jobs. This helps users track how long a job took and when it definitively concluded.

Changes:
1. `JobResponse` now has an optional `completed_at` string.
2. The `update_job_status` function attaches the current UTC timestamp to a job state when it transitions to a terminal state.
3. The frontend job card layout was modified to display this completed timestamp seamlessly.
4. Related backend tests were updated to cover these fields.
5. The original backlog issue was moved to `docs/backlog/closed/`.

---
*PR created automatically by Jules for task [16452395747884141390](https://jules.google.com/task/16452395747884141390) started by @jjgroenendijk*