### PR TITLE
feat(ui): display execution duration for completed, failed, and cancelled jobs

### DIFF
--- a/docs/backlog/closed/display_job_execution_duration.md
+++ b/docs/backlog/closed/display_job_execution_duration.md
@@ -1,0 +1,11 @@
+# Display Job Execution Duration
+
+## Requirement
+As a user, I want to see the execution duration for completed, failed, and cancelled jobs in the SpotiFLAC web UI so that I can monitor system performance and job runtimes.
+
+## Implementation Details
+1. Modify `website/src/app.js` and specifically the `renderJob(job)` function.
+2. If `job.completed_at` is set, parse `job.created_at` and `job.completed_at` into `Date` objects.
+3. Calculate the difference in milliseconds and format it into a human-readable string (e.g. `1m 23s` or `45s`).
+4. Display the formatted duration in the `.job-source` element where `Completed:` timestamp is rendered.
+5. Add relevant unit tests if necessary (though the E2E tests and simple UI modification should suffice for basic functionality validation).

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -47,7 +47,23 @@ function renderJob(job) {
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
   const urlType = classifySpotifyUrl(job.url);
-  const completedAtHtml = job.completed_at ? `<p class="job-source" style="margin-top: 4px;">Completed: ${new Date(job.completed_at).toLocaleString()}</p>` : "";
+
+  let durationText = "";
+  if (job.completed_at && job.created_at) {
+    const durationMs = new Date(job.completed_at) - new Date(job.created_at);
+    if (durationMs >= 0) {
+      const totalSeconds = Math.floor(durationMs / 1000);
+      const minutes = Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      if (minutes > 0) {
+        durationText = ` (${minutes}m ${seconds}s)`;
+      } else {
+        durationText = ` (${seconds}s)`;
+      }
+    }
+  }
+
+  const completedAtHtml = job.completed_at ? `<p class="job-source" style="margin-top: 4px;">Completed: ${new Date(job.completed_at).toLocaleString()}${durationText}</p>` : "";
 
   return `
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">


### PR DESCRIPTION
This implements the feature to display job execution duration on the frontend UI for completed, failed, or cancelled jobs.

---
*PR created automatically by Jules for task [13914513225834484147](https://jules.google.com/task/13914513225834484147) started by @jjgroenendijk*