### PR TITLE
feat: Add job statistics to dashboard

### DIFF
--- a/docs/backlog/closed/add_job_stats.md
+++ b/docs/backlog/closed/add_job_stats.md
@@ -1,0 +1,11 @@
+# Add job stats functionality
+
+## Description
+Provide high-level stats about downloaded files and execution times on the SpotiFLAC dashboard, to give homelab users an overview of usage.
+
+## Implementation details
+- Backend should expose a new endpoint `/api/stats` that reads through history and calculates:
+  - Total jobs
+  - Total files downloaded
+  - Success rate
+- Frontend should display these stats near the storage panel.

--- a/server.py
+++ b/server.py
@@ -636,6 +636,45 @@ async def cancel_job(job_id: str):
 
     return {"status": "success"}
 
+def _calculate_stats():
+    import json
+    if not HISTORY_FILE.exists():
+        return {"total_jobs": 0, "total_files": 0, "success_rate": 0}
+
+    try:
+        with open(HISTORY_FILE, "r") as f:
+            history = json.load(f)
+    except json.JSONDecodeError:
+        return {"total_jobs": 0, "total_files": 0, "success_rate": 0}
+
+    total_jobs = len(history)
+    if total_jobs == 0:
+        return {"total_jobs": 0, "total_files": 0, "success_rate": 0}
+
+    total_files = sum(job.get("files", 0) for job in history)
+    completed_jobs = sum(1 for job in history if job.get("status") == "Completed")
+
+    # Calculate success rate as a percentage
+    # To avoid counting currently running/queued jobs as failures, we could either
+    # calculate rate out of finished jobs only, or total jobs. Let's do total jobs for simplicity,
+    # or finished jobs (Completed + Failed) for a more accurate rate.
+    # Let's use (Completed / (Completed + Failed)) if there are finished jobs, else 0
+    finished_jobs = sum(1 for job in history if job.get("status") in ["Completed", "Failed"])
+    if finished_jobs > 0:
+        success_rate = round((completed_jobs / finished_jobs) * 100)
+    else:
+        success_rate = 0
+
+    return {
+        "total_jobs": total_jobs,
+        "total_files": total_files,
+        "success_rate": success_rate
+    }
+
+@app.get("/api/stats")
+async def get_stats():
+    return await asyncio.to_thread(_calculate_stats)
+
 @app.get("/api/system/storage")
 def get_system_storage():
     try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -485,3 +485,33 @@ def test_get_system_storage(tmp_path, monkeypatch):
     assert isinstance(data["total"], int)
     assert isinstance(data["used"], int)
     assert isinstance(data["free"], int)
+
+def test_get_stats_empty(tmp_path, monkeypatch):
+    history_file = tmp_path / "history.json"
+    monkeypatch.setattr("server.HISTORY_FILE", history_file)
+
+    response = client.get("/api/stats")
+    assert response.status_code == 200
+    assert response.json() == {"total_jobs": 0, "total_files": 0, "success_rate": 0}
+
+def test_get_stats_with_data(tmp_path, monkeypatch):
+    history_file = tmp_path / "history.json"
+    monkeypatch.setattr("server.HISTORY_FILE", history_file)
+
+    history_data = [
+        {"id": "job-1", "status": "Completed", "files": 5},
+        {"id": "job-2", "status": "Failed", "files": 0},
+        {"id": "job-3", "status": "Running"},
+        {"id": "job-4", "status": "Completed", "files": 2},
+    ]
+    with open(history_file, "w") as f:
+        json.dump(history_data, f)
+
+    response = client.get("/api/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_jobs"] == 4
+    assert data["total_files"] == 7
+    # 2 completed, 1 failed, 1 running
+    # Finished = 3, Completed = 2 -> 2/3 * 100 = 67%
+    assert data["success_rate"] == 67

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -133,6 +133,20 @@ export function renderApp(root) {
             <div class="storage-progress-bar-fill" id="storage-progress-fill" style="width: 0%;"></div>
           </div>
           <p id="storage-usage-text">Job history, logs, and produced files will persist outside the container.</p>
+          <div id="job-stats-container" style="margin-top: 16px; font-size: 0.85rem; color: var(--text-secondary); display: grid; grid-template-columns: 1fr 1fr; gap: 8px;">
+            <div>
+              <strong style="color: var(--text-primary);">Total Jobs</strong>
+              <p id="stat-total-jobs" style="margin: 2px 0 0 0;">-</p>
+            </div>
+            <div>
+              <strong style="color: var(--text-primary);">Total Files</strong>
+              <p id="stat-total-files" style="margin: 2px 0 0 0;">-</p>
+            </div>
+            <div style="grid-column: 1 / -1;">
+              <strong style="color: var(--text-primary);">Success Rate</strong>
+              <p id="stat-success-rate" style="margin: 2px 0 0 0;">-</p>
+            </div>
+          </div>
         </aside>
       </section>
 
@@ -224,6 +238,25 @@ export function renderApp(root) {
     const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+  }
+
+  async function updateJobStats() {
+    try {
+      const response = await fetch("/api/stats");
+      if (response.ok) {
+        const data = await response.json();
+
+        const totalJobsEl = root.querySelector("#stat-total-jobs");
+        const totalFilesEl = root.querySelector("#stat-total-files");
+        const successRateEl = root.querySelector("#stat-success-rate");
+
+        if (totalJobsEl) totalJobsEl.textContent = data.total_jobs;
+        if (totalFilesEl) totalFilesEl.textContent = data.total_files;
+        if (successRateEl) successRateEl.textContent = `${data.success_rate}%`;
+      }
+    } catch (err) {
+      console.error("Failed to fetch job stats", err);
+    }
   }
 
   async function updateStorageUsage() {
@@ -355,6 +388,7 @@ export function renderApp(root) {
       pollInterval = setInterval(() => {
         fetchJobs();
         updateStorageUsage();
+        updateJobStats();
       }, 5000);
     }
   }
@@ -372,6 +406,7 @@ export function renderApp(root) {
   // Initial load
   fetchJobs();
   updateStorageUsage();
+  updateJobStats();
   applyAutoRefreshState();
 
   const themeToggleBtn = root.querySelector("#theme-toggle");


### PR DESCRIPTION
This PR implements high-level job statistics for the SpotiFLAC web dashboard.

Changes:
1.  **Backend (`server.py`)**: Added a new `/api/stats` endpoint that reads the `HISTORY_FILE` in a non-blocking background thread using `asyncio.to_thread`. It calculates total jobs, total files, and a success rate percentage based on finished jobs (completed + failed).
2.  **Frontend (`website/src/app.js`)**: Added a stats container below the storage usage panel that displays "Total Jobs", "Total Files", and "Success Rate". Added `updateJobStats()` which polls `/api/stats`, and tied it into the initial load and the auto-refresh interval.
3.  **Tests (`tests/test_server.py`)**: Added unit tests for the `/api/stats` endpoint to verify empty and populated history states.
4.  **Workflow**: Moved the corresponding requirements doc to the closed backlog folder.

---
*PR created automatically by Jules for task [1283532797751691525](https://jules.google.com/task/1283532797751691525) started by @jjgroenendijk*