### PR TITLE
feat: display job execution duration on job cards

### DIFF
--- a/docs/backlog/closed/023-job-duration.md
+++ b/docs/backlog/closed/023-job-duration.md
@@ -1,0 +1,10 @@
+# Add Job Execution Duration Display
+
+## Description
+Display the execution duration (time elapsed between job creation and completion) on the job cards for completed, failed, and cancelled jobs in the web UI. This provides better visibility into system performance for homelab users.
+
+## Tasks
+1. Update `website/src/app.js` to parse `created_at` and `completed_at` and format the duration (e.g., 'Duration: 1m 23s').
+2. Render this duration next to the 'Completed: ...' timestamp.
+3. Add a unit test in `website/src/app.test.js` to verify the duration is calculated and rendered correctly.
+4. Update mock jobs in Playwright tests to include `completed_at` where necessary to prevent regressions.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -22,6 +22,23 @@ export function classifySpotifyUrl(value) {
   return new URL(value).pathname.split("/").filter(Boolean)[0];
 }
 
+function formatDuration(startStr, endStr) {
+  if (!startStr || !endStr) return "";
+  const start = new Date(startStr);
+  const end = new Date(endStr);
+  if (isNaN(start) || isNaN(end)) return "";
+
+  const diffMs = Math.max(0, end - start);
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
 function escapeHtml(unsafe) {
     if (!unsafe) return '';
     return unsafe
@@ -47,7 +64,8 @@ function renderJob(job) {
 
   const progressHtml = job.status === "Running" ? `<div class="job-progress" id="progress-container-${escapeHtml(job.id)}" style="grid-column: 1 / -1; margin-top: 8px; font-size: 0.85rem; color: #476154;">Loading progress...</div>` : "";
   const urlType = classifySpotifyUrl(job.url);
-  const completedAtHtml = job.completed_at ? `<p class="job-source" style="margin-top: 4px;">Completed: ${new Date(job.completed_at).toLocaleString()}</p>` : "";
+  const durationStr = formatDuration(job.created_at, job.completed_at);
+  const completedAtHtml = job.completed_at ? `<p class="job-source" style="margin-top: 4px;">Completed: ${new Date(job.completed_at).toLocaleString()} (Duration: ${durationStr})</p>` : "";
 
   return `
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -461,4 +461,47 @@ describe("renderApp", () => {
     expect(downloadAllBtn.getAttribute("href")).toBe("/api/history/download");
     expect(downloadAllBtn.hasAttribute("download")).toBe(true);
   });
+
+  it("calculates and renders the correct execution duration for a completed job", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementation((url, options) => {
+      if (url === "/api/jobs" && (!options || options.method === "GET")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: "duration-job",
+              url: "https://open.spotify.com/track/duration",
+              status: "Completed",
+              created_at: "2023-01-01T00:00:00.000Z",
+              completed_at: "2023-01-01T00:01:23.000Z" // 1m 23s later
+            }
+          ])
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+    global.fetch = fetchMock;
+
+    renderApp(root);
+
+    // Allow async handlers to complete
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const durationText = document.body.textContent;
+    expect(durationText).toContain("(Duration: 1m 23s)");
+  });
 });

--- a/website/tests/sort.spec.js
+++ b/website/tests/sort.spec.js
@@ -12,6 +12,7 @@ test.beforeEach(async ({ page }) => {
             id: "older-job",
             url: "https://open.spotify.com/album/older",
             status: "Completed",
+            completed_at: new Date(Date.now() - 1000).toISOString(),
             created_at: new Date(Date.now() - 100000).toISOString(),
             files: 10,
             error_log: null
@@ -20,6 +21,7 @@ test.beforeEach(async ({ page }) => {
             id: "newer-job",
             url: "https://open.spotify.com/album/newer",
             status: "Completed",
+            completed_at: new Date(Date.now() - 1000).toISOString(),
             created_at: new Date().toISOString(),
             files: 10,
             error_log: null

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -254,6 +254,7 @@ test('can view job logs', async ({ page }) => {
         id: 'mock-job-id',
         url: 'https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy',
         status: 'Completed',
+        completed_at: new Date(Date.now() - 1000).toISOString(),
         created_at: new Date().toISOString(),
         files: 10
       }];
@@ -613,6 +614,7 @@ test('displays Download All button on job card when completed', async ({ page })
             id: 'job-12345',
             url: 'https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX',
             status: 'Completed',
+        completed_at: new Date(Date.now() - 1000).toISOString(),
             created_at: new Date().toISOString(),
             files: 10,
             error_log: null
@@ -649,6 +651,7 @@ test('displays Download all completed button when completed jobs exist', async (
             id: '123',
             url: 'https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX',
             status: 'Completed',
+        completed_at: new Date(Date.now() - 1000).toISOString(),
             created_at: new Date().toISOString(),
             files: 10,
             error_log: null
@@ -784,6 +787,7 @@ test('search input filters jobs by URL and ID', async ({ page }) => {
             id: 'job-111',
             url: 'https://open.spotify.com/track/alpha',
             status: 'Completed',
+        completed_at: new Date(Date.now() - 1000).toISOString(),
             created_at: new Date(Date.now() - 2000).toISOString(),
             files: 1,
             error_log: null
@@ -839,6 +843,7 @@ test('renders audio player for audio files', async ({ page }) => {
             id: 'job-audio',
             url: 'https://open.spotify.com/track/audio1',
             status: 'Completed',
+        completed_at: new Date(Date.now() - 1000).toISOString(),
             created_at: new Date().toISOString(),
             files: 2,
             error_log: null


### PR DESCRIPTION
This submission adds a new feature to the UI: displaying the total execution duration for completed jobs. It calculates the difference between `created_at` and `completed_at`, formats it readably, and displays it inside the job card details. Unit tests and visual verification tests successfully validate the changes.

---
*PR created automatically by Jules for task [8007972139127303850](https://jules.google.com/task/8007972139127303850) started by @jjgroenendijk*