### PR TITLE
feat: add copy job URL button to web UI

### DIFF
--- a/docs/backlog/closed/01-copy-job-url.md
+++ b/docs/backlog/closed/01-copy-job-url.md
@@ -1,0 +1,10 @@
+# Copy Job URL Button
+
+## Context
+In the web UI, job cards show the Spotify URL. It would be helpful to have a button to easily copy the URL to the clipboard.
+
+## Requirements
+- Render a "Copy" button next to the URL in the `.job-title` element.
+- When clicked, it should use the `navigator.clipboard.writeText` API to copy the URL.
+- Show a brief "Copied!" feedback text on the button when successful, then revert back to "Copy" after 2 seconds.
+- Update tests.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -74,6 +74,7 @@ function renderJob(job) {
         <p class="job-title">
           <a href="${escapeHtml(job.url)}" target="_blank" rel="noopener noreferrer" class="source-link">${escapeHtml(job.url)}</a>
           <span class="url-type-badge" style="font-size: 0.75rem; background: rgba(255,255,255,0.2); padding: 2px 6px; border-radius: 4px; margin-left: 8px; text-transform: capitalize; vertical-align: middle;">${escapeHtml(urlType)}</span>
+          <button type="button" class="copy-url-btn" data-job-url="${escapeHtml(job.url)}" style="font-size: 0.75rem; padding: 2px 6px; margin-left: 8px; vertical-align: middle; border: 1px solid var(--border-color); background: transparent; color: var(--text-secondary); cursor: pointer; border-radius: 4px;">Copy</button>
         </p>
         <p class="job-source">Started: ${new Date(job.created_at).toLocaleString()}</p>
         ${completedAtHtml}
@@ -685,6 +686,26 @@ export function renderApp(root) {
         console.error("Failed to delete job", err);
         event.target.disabled = false;
         event.target.textContent = "Delete";
+      }
+    }
+
+    if (event.target.classList.contains("copy-url-btn")) {
+      const jobUrl = event.target.dataset.jobUrl;
+      if (!jobUrl) return;
+
+      try {
+        await navigator.clipboard.writeText(jobUrl);
+        const btn = event.target;
+        const originalText = btn.textContent;
+        btn.textContent = "Copied!";
+        btn.disabled = true;
+
+        setTimeout(() => {
+          btn.textContent = originalText;
+          btn.disabled = false;
+        }, 2000);
+      } catch (err) {
+        console.error("Failed to copy URL", err);
       }
     }
   });

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -462,6 +462,81 @@ describe("renderApp", () => {
     expect(downloadAllBtn.hasAttribute("download")).toBe(true);
   });
 
+  it("copies job URL to clipboard when copy button is clicked", async () => {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    // Mock clipboard API
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue()
+      },
+      writable: true
+    });
+
+    const root = document.getElementById("root");
+
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementation((url, options) => {
+      if (url === "/api/jobs" && (!options || options.method === "GET")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: "copy-job-1",
+              url: "https://open.spotify.com/track/copy123",
+              status: "Completed",
+              created_at: "2023-01-01T00:00:00Z"
+            }
+          ])
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+    global.fetch = fetchMock;
+
+    renderApp(root);
+
+    // Allow async handlers to complete
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Use fake timers to test setTimeout, after the async initialization
+    vi.useFakeTimers();
+
+    const copyBtn = document.querySelector(".copy-url-btn");
+    expect(copyBtn).not.toBeNull();
+    expect(copyBtn.getAttribute("data-job-url")).toBe("https://open.spotify.com/track/copy123");
+    expect(copyBtn.textContent).toBe("Copy");
+    expect(copyBtn.disabled).toBe(false);
+
+    // Simulate click
+    copyBtn.click();
+
+    // Verify clipboard was called
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith("https://open.spotify.com/track/copy123");
+
+    // Wait for the async click handler to finish the try block
+    await Promise.resolve();
+
+    // Verify button text changed
+    expect(copyBtn.textContent).toBe("Copied!");
+    expect(copyBtn.disabled).toBe(true);
+
+    // Advance time by 2 seconds
+    vi.advanceTimersByTime(2000);
+
+    // Verify button reverted
+    expect(copyBtn.textContent).toBe("Copy");
+    expect(copyBtn.disabled).toBe(false);
+
+    vi.useRealTimers();
+  });
+
   it("calculates and renders the correct execution duration for a completed job", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",


### PR DESCRIPTION
This PR adds a small quality-of-life feature to the web UI. Job cards now feature a "Copy" button next to the Spotify URL. When clicked, it copies the URL to the user's clipboard and provides a brief visual confirmation ("Copied!") before reverting back to its default state. This helps users quickly grab URLs without manually selecting the text. Thorough unit tests covering both the functionality and UI states have been added.

---
*PR created automatically by Jules for task [14388109995638647357](https://jules.google.com/task/14388109995638647357) started by @jjgroenendijk*