### PR TITLE
Add manual log refresh button

### DIFF
--- a/docs/backlog/closed/012_manual_log_refresh.md
+++ b/docs/backlog/closed/012_manual_log_refresh.md
@@ -1,0 +1,11 @@
+# 012 Add manual log refresh button
+
+## Goal
+Add a button to manually refresh the logs of a job while viewing them.
+
+## Why
+When viewing execution logs for running jobs, they do not auto-refresh. The user must close and reopen the logs to see updates. A simple "Refresh Logs" button near the "Close" button would improve the experience.
+
+## Status
+- [x] Implement the feature in frontend.
+- [x] Verify locally and move this item to `docs/backlog/closed/`.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -103,7 +103,10 @@ function renderJob(job) {
       <div class="job-logs-container" id="logs-container-${escapeHtml(job.id)}" style="display: none; grid-column: 1 / -1;">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
           <h3 style="margin: 0; font-size: 0.9rem; color: #476154;">Execution Logs</h3>
-          <button type="button" class="close-logs-btn" data-job-id="${escapeHtml(job.id)}" style="padding: 4px 8px; font-size: 0.75rem; min-height: auto;">Close</button>
+          <div>
+            <button type="button" class="refresh-logs-btn" data-job-id="${escapeHtml(job.id)}" style="padding: 4px 8px; font-size: 0.75rem; min-height: auto; margin-right: 8px;">Refresh Logs</button>
+            <button type="button" class="close-logs-btn" data-job-id="${escapeHtml(job.id)}" style="padding: 4px 8px; font-size: 0.75rem; min-height: auto;">Close</button>
+          </div>
         </div>
         <pre class="job-logs-content" id="logs-content-${escapeHtml(job.id)}">Loading...</pre>
       </div>
@@ -561,6 +564,40 @@ export function renderApp(root) {
       const logsContainer = root.querySelector(`#logs-container-${jobId}`);
       if (logsContainer) {
         logsContainer.style.display = "none";
+      }
+    }
+
+    if (event.target.classList.contains("refresh-logs-btn")) {
+      const jobId = event.target.dataset.jobId;
+      if (!jobId) return;
+
+      const btn = event.target;
+      const logsContent = root.querySelector(`#logs-content-${jobId}`);
+
+      btn.disabled = true;
+      const originalText = btn.textContent;
+      btn.textContent = "Refreshing...";
+
+      try {
+        const response = await fetch(`/api/jobs/${jobId}/log`);
+        if (response.ok) {
+          const data = await response.json();
+          if (logsContent) {
+            logsContent.textContent = data.log || "No logs available.";
+          }
+        } else {
+          if (logsContent) {
+            logsContent.textContent = "Failed to load logs.";
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch logs", err);
+        if (logsContent) {
+          logsContent.textContent = "Failed to load logs.";
+        }
+      } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
       }
     }
 

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -890,6 +890,72 @@ test('renders audio player for audio files', async ({ page }) => {
   expect(nonAudioCount).toBe(0);
 });
 
+test('manual log refresh button updates logs', async ({ page }) => {
+  let logCalls = 0;
+
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-refresh-logs',
+            url: 'https://open.spotify.com/track/refresh-logs',
+            status: 'Running',
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ])
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.route('/api/jobs/job-refresh-logs/log', async (route) => {
+    logCalls++;
+    if (logCalls === 1) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ log: 'Log line 1' })
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ log: 'Log line 1\nLog line 2' })
+      });
+    }
+  });
+
+  await page.goto('/');
+
+  const jobCard = page.locator('.job-card[data-job-id="job-refresh-logs"]');
+  await expect(jobCard).toBeVisible();
+
+  // Click View Logs
+  const viewLogsBtn = jobCard.locator('button.view-logs-btn');
+  await expect(viewLogsBtn).toBeVisible();
+  await viewLogsBtn.click();
+
+  const logsContainer = page.locator('#logs-container-job-refresh-logs');
+  await expect(logsContainer).toBeVisible();
+
+  const logsContent = logsContainer.locator('#logs-content-job-refresh-logs');
+  await expect(logsContent).toHaveText('Log line 1');
+
+  // Click Refresh Logs
+  const refreshLogsBtn = logsContainer.locator('button.refresh-logs-btn');
+  await expect(refreshLogsBtn).toBeVisible();
+  await refreshLogsBtn.click();
+
+  // Verify updated logs
+  await expect(logsContent).toHaveText('Log line 1\nLog line 2');
+});
+
 test("filters jobs by type", async ({ page }) => {
   await page.route("/api/jobs", async (route) => {
     if (route.request().method() === "GET") {


### PR DESCRIPTION
This PR implements the manual log refresh functionality as described in backlog item `012_manual_log_refresh.md`.

It introduces a "Refresh Logs" button adjacent to the "Close" button when viewing execution logs. Clicking it triggers a new API request to fetch the latest logs, disables the button temporarily with a "Refreshing..." state, and then seamlessly updates the DOM with the newly fetched text.

This significantly improves the UX for viewing long-running jobs, negating the need to constantly close and open the logs modal. Playwright E2E tests have been added to verify that clicking the button successfully retrieves updated logs.

---
*PR created automatically by Jules for task [7548125484967691219](https://jules.google.com/task/7548125484967691219) started by @jjgroenendijk*