### PR TITLE
feat: add clear input functionality to job queue form

### DIFF
--- a/docs/backlog/closed/024-clear-input.md
+++ b/docs/backlog/closed/024-clear-input.md
@@ -1,0 +1,1 @@
+We need to clear the text input field containing the spotify URLs after clicking queue or a user hitting submit. And we should probably provide a 'Clear Input' button next to the input area to wipe the field.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -143,6 +143,7 @@ export function renderApp(root) {
               required
               rows="3"
             ></textarea>
+            <button type="button" id="clear-input-btn" class="clear-history-btn">Clear input</button>
             <button type="submit">Queue</button>
           </div>
           <p class="hint" id="queue-feedback">Tracks, albums, and playlists will run through the SpotiFLAC module.</p>
@@ -228,6 +229,15 @@ export function renderApp(root) {
   const statusFilter = root.querySelector("#job-status-filter");
   const searchInput = root.querySelector("#job-search-input");
   const sortSelect = root.querySelector("#job-sort-select");
+  const clearInputBtn = root.querySelector("#clear-input-btn");
+
+  if (clearInputBtn) {
+    clearInputBtn.addEventListener("click", () => {
+      input.value = "";
+      feedback.textContent = "Tracks, albums, and playlists will run through the SpotiFLAC module.";
+      feedback.dataset.state = "";
+    });
+  }
 
   async function updateProgress(jobId) {
     const container = root.querySelector(`#progress-container-${jobId}`);
@@ -491,6 +501,9 @@ export function renderApp(root) {
     queueBtn.disabled = true;
     queueBtn.textContent = "Queueing...";
 
+    // Clear the text input immediately upon submitting
+    input.value = "";
+
     try {
       const requests = urls.map(url =>
         fetch("/api/jobs", {
@@ -508,8 +521,6 @@ export function renderApp(root) {
       if (successCount === 0) {
         throw new Error("Failed to queue all jobs");
       }
-
-      input.value = "";
 
       if (failedCount === 0) {
         feedback.textContent = `Successfully queued ${successCount} job${successCount > 1 ? 's' : ''}.`;

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -250,7 +250,7 @@ label {
 
 .url-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   gap: 10px;
 }
 

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1162,3 +1162,31 @@ test('can queue multiple comma-separated URLs', async ({ page }) => {
   expect(queuedUrls).toContain('https://open.spotify.com/track/2');
   expect(queuedUrls).toContain('https://open.spotify.com/track/3');
 });
+
+test("can clear input field manually", async ({ page }) => {
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([])
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  const input = page.locator("#spotify-url");
+  await input.fill("https://open.spotify.com/track/123");
+  await expect(input).toHaveValue("https://open.spotify.com/track/123");
+
+  const clearBtn = page.locator("#clear-input-btn");
+  await clearBtn.click();
+
+  await expect(input).toHaveValue("");
+
+  const feedback = page.locator("#queue-feedback");
+  await expect(feedback).toContainText("Tracks, albums, and playlists will run through the SpotiFLAC module.");
+});


### PR DESCRIPTION
This PR addresses backlog item `024-clear-input.md` by implementing two features to improve the user experience of the Spotify URL input field:

1. **Immediate Clearing on Submission**: The input field is now wiped immediately when the user clicks 'Queue' or hits Enter, rather than waiting for the API response.
2. **Clear Input Button**: Added a dedicated 'Clear Input' button next to the 'Queue' button. Clicking it clears the text area and resets the informative feedback text to its default state. 
3. **UI Adjustments**: Updated the CSS grid (`.url-row`) to accommodate the three elements nicely.
4. **Testing**: Included an end-to-end Playwright test to verify the functionality of the 'Clear Input' button.

---
*PR created automatically by Jules for task [5569609701537825969](https://jules.google.com/task/5569609701537825969) started by @jjgroenendijk*