### PR TITLE
feat: add compact view toggle to job list

### DIFF
--- a/docs/backlog/closed/001-compact-view.md
+++ b/docs/backlog/closed/001-compact-view.md
@@ -1,0 +1,3 @@
+# Add Compact View for Job List
+
+As a user, I want a toggle to display the job list in a compact, dense format to see more jobs at once without excessive scrolling.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -210,6 +210,10 @@ export function renderApp(root) {
               <input type="checkbox" id="auto-refresh-toggle" style="width: auto; min-height: auto; margin: 0; cursor: pointer;">
               Auto-refresh
             </label>
+            <label style="display: flex; align-items: center; gap: 4px; margin: 0; font-size: 0.85rem; color: var(--text-primary); cursor: pointer;">
+              <input type="checkbox" id="compact-view-toggle" style="width: auto; min-height: auto; margin: 0; cursor: pointer;">
+              Compact view
+            </label>
             <button type="button" id="clear-completed-btn" class="clear-history-btn" style="border-color: rgba(16, 185, 129, 0.5); color: #10b981;">Clear completed</button>
             <button type="button" id="retry-failed-btn" class="clear-history-btn" style="border-color: rgba(234, 179, 8, 0.5); color: #eab308;">Retry failed</button>
             <button type="button" id="clear-failed-btn" class="clear-history-btn" style="border-color: rgba(220, 38, 38, 0.5); color: #dc2626;">Clear failed</button>
@@ -443,8 +447,28 @@ export function renderApp(root) {
     });
   }
 
+  const compactViewToggle = root.querySelector("#compact-view-toggle");
+  function applyCompactViewState() {
+    if (compactViewToggle && compactViewToggle.checked) {
+      jobList.classList.add("compact");
+    } else {
+      jobList.classList.remove("compact");
+    }
+  }
+
+  if (compactViewToggle) {
+    const savedCompactView = localStorage.getItem("compactView");
+    compactViewToggle.checked = savedCompactView === "true";
+
+    compactViewToggle.addEventListener("change", () => {
+      localStorage.setItem("compactView", compactViewToggle.checked);
+      applyCompactViewState();
+    });
+  }
+
   // Initial load
   fetchJobs();
+  applyCompactViewState();
   updateStorageUsage();
   updateJobStats();
   applyAutoRefreshState();

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -351,6 +351,10 @@ button:active {
   gap: 10px;
 }
 
+.job-list.compact {
+  gap: 6px;
+}
+
 .job-card {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -358,6 +362,15 @@ button:active {
   align-items: center;
   padding: 16px;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.job-list.compact .job-card {
+  padding: 8px;
+  gap: 10px;
+}
+
+.job-list.compact .track-cover {
+  display: none;
 }
 
 .track-cover {

--- a/website/tests/compact-view.spec.js
+++ b/website/tests/compact-view.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Compact View Toggle', () => {
+  test('should toggle compact view class and hide track covers', async ({ page }) => {
+    // Navigate to the app
+    await page.goto('/');
+
+    // Ensure the toggle is visible
+    const compactToggle = page.locator('#compact-view-toggle');
+    await expect(compactToggle).toBeVisible();
+
+    // Initially, it should not have the compact class
+    const jobList = page.locator('#job-list');
+    await expect(jobList).not.toHaveClass(/compact/);
+
+    // Create a mock job so we have a track cover to check
+    // We can do this by mocking the API response or creating a job if the backend is running.
+    // For simplicity, we'll intercept the API to return a mock job.
+    await page.route('/api/jobs', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'mock-job-1',
+            url: 'https://open.spotify.com/track/mock1',
+            status: 'Completed',
+            created_at: new Date().toISOString()
+          }
+        ])
+      });
+    });
+
+    // Reload to apply the mock
+    await page.goto('/');
+
+    // Check that the track cover is visible initially
+    const trackCover = page.locator('.track-cover').first();
+    await expect(trackCover).toBeVisible();
+
+    // Check the compact view toggle
+    await compactToggle.check();
+
+    // The job list should now have the compact class
+    await expect(jobList).toHaveClass(/compact/);
+
+    // The track cover should be hidden
+    await expect(trackCover).toBeHidden();
+
+    // Take a screenshot to verify visually
+    await page.screenshot({ path: 'compact-view-test.png' });
+
+    // Uncheck to verify it toggles back
+    await compactToggle.uncheck();
+    await expect(jobList).not.toHaveClass(/compact/);
+    await expect(trackCover).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implemented a "Compact View" feature for the job list to allow users to see more jobs at once with less scrolling. 

Key changes:
- Added a "Compact view" checkbox toggle next to the "Auto-refresh" toggle.
- Added corresponding `.compact` CSS classes to reduce padding/gap and hide track covers on job cards.
- Wired up the toggle logic in JavaScript to persist the state using `localStorage`.
- Wrote a new Playwright E2E test (`compact-view.spec.js`) to verify the toggling behavior and ensure track covers are hidden.
- Created and then closed the corresponding backlog issue `docs/backlog/closed/001-compact-view.md` as per workflow.

---
*PR created automatically by Jules for task [8813438818877296793](https://jules.google.com/task/8813438818877296793) started by @jjgroenendijk*