### PR TITLE
Add Download All Logs functionality

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, HttpUrl
 

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import json
 import logging
 import os
@@ -9,7 +10,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, HttpUrl
 
@@ -408,6 +409,37 @@ def download_all_completed_jobs(background_tasks: BackgroundTasks):
         path=zip_path,
         media_type="application/zip",
         filename="SpotiFLAC-all-completed.zip"
+    )
+
+def _create_all_logs_zip() -> io.BytesIO | None:
+    import zipfile
+
+    if not LOGS_DIR.exists() or not LOGS_DIR.is_dir():
+        return None
+
+    log_files = list(LOGS_DIR.glob("*.log"))
+    if not log_files:
+        return None
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for f in log_files:
+            zip_file.write(f, arcname=f.name)
+
+    zip_buffer.seek(0)
+    return zip_buffer
+
+@app.get("/api/history/logs/download")
+async def download_all_logs():
+    from fastapi import Response
+    zip_buffer = await asyncio.to_thread(_create_all_logs_zip)
+    if zip_buffer is None:
+        raise HTTPException(status_code=404, detail="No logs found")
+
+    return Response(
+        content=zip_buffer.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=SpotiFLAC-all-logs.zip"}
     )
 
 @app.get("/api/history/export")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -515,3 +515,45 @@ def test_get_stats_with_data(tmp_path, monkeypatch):
     # 2 completed, 1 failed, 1 running
     # Finished = 3, Completed = 2 -> 2/3 * 100 = 67%
     assert data["success_rate"] == 67
+
+@patch('server.LOGS_DIR')
+def test_download_all_logs_success(mock_logs_dir, tmp_path):
+    import io
+    import zipfile
+
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create mock logs
+    (logs_dir / "job1.log").write_text("log output 1")
+    (logs_dir / "job2.log").write_text("log output 2")
+
+    mock_logs_dir.exists.return_value = True
+    mock_logs_dir.is_dir.return_value = True
+    mock_logs_dir.glob.return_value = logs_dir.glob("*.log")
+
+    response = client.get("/api/history/logs/download")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert "attachment; filename=SpotiFLAC-all-logs.zip" in response.headers["content-disposition"]
+
+    # Verify zip content
+    zip_data = io.BytesIO(response.content)
+    with zipfile.ZipFile(zip_data, "r") as zip_file:
+        files = zip_file.namelist()
+        assert "job1.log" in files
+        assert "job2.log" in files
+        assert zip_file.read("job1.log") == b"log output 1"
+
+@patch('server.LOGS_DIR')
+def test_download_all_logs_not_found(mock_logs_dir, tmp_path):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    mock_logs_dir.exists.return_value = True
+    mock_logs_dir.is_dir.return_value = True
+    mock_logs_dir.glob.return_value = []
+
+    response = client.get("/api/history/logs/download")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No logs found"

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -205,6 +205,7 @@ export function renderApp(root) {
               <option value="Cancelled">Cancelled</option>
             </select>
             <a href="/api/history/download" id="download-all-btn" class="clear-history-btn" download style="text-decoration: none;">Download all completed</a>
+            <a href="/api/history/logs/download" id="download-all-logs-btn" class="clear-history-btn" download style="text-decoration: none;">Download all logs</a>
             <button type="button" id="refresh-jobs-btn" class="clear-history-btn">Refresh jobs</button>
             <label style="display: flex; align-items: center; gap: 4px; margin: 0; font-size: 0.85rem; color: var(--text-primary); cursor: pointer;">
               <input type="checkbox" id="auto-refresh-toggle" style="width: auto; min-height: auto; margin: 0; cursor: pointer;">

--- a/website/tests/download-logs.spec.js
+++ b/website/tests/download-logs.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Download All Logs Button', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the /api/jobs GET request
+    await page.route('/api/jobs', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([])
+      });
+    });
+
+    // Mock stats request
+    await page.route('/api/stats', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          total_jobs: 0,
+          total_files: 0,
+          success_rate: 0
+        })
+      });
+    });
+
+    // Mock storage request
+    await page.route('/api/system/storage', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          total: 10000000000,
+          used: 2000000000,
+          free: 8000000000
+        })
+      });
+    });
+  });
+
+  test('should display the Download all logs button with correct href', async ({ page }) => {
+    await page.goto('/');
+
+    const downloadLogsBtn = page.locator('#download-all-logs-btn');
+
+    // Verify visibility
+    await expect(downloadLogsBtn).toBeVisible();
+
+    // Verify text content
+    await expect(downloadLogsBtn).toHaveText('Download all logs');
+
+    // Verify href attribute
+    await expect(downloadLogsBtn).toHaveAttribute('href', '/api/history/logs/download');
+
+    // Verify download attribute
+    await expect(downloadLogsBtn).toHaveAttribute('download', '');
+  });
+});


### PR DESCRIPTION
Implements the "Download All Logs" requirement from the backlog.

- **Backend:** Added `/api/history/logs/download` endpoint in `server.py` that zips all `.log` files in the `LOGS_DIR` and returns the archive. The zip process is safely offloaded to a thread using `asyncio.to_thread`.
- **Frontend:** Placed a "Download all logs" button alongside the other history action buttons in the web UI.
- **Testing:** Provided complete test coverage, including backend tests (`tests/test_server.py`) for both successful log archiving and the 404 case, and a Playwright E2E test (`website/tests/download-logs.spec.js`) to verify the frontend UI button's visibility and correct `href` values.
- Moved the backlog requirement to the `docs/backlog/closed/` directory. All tests pass locally.

---
*PR created automatically by Jules for task [17493364537111155086](https://jules.google.com/task/17493364537111155086) started by @jjgroenendijk*