### PR TITLE
Auto-refresh stats and storage usage

### DIFF
--- a/docs/backlog/closed/auto-refresh-stats.md
+++ b/docs/backlog/closed/auto-refresh-stats.md
@@ -1,0 +1,6 @@
+# System stats auto-refresh requirement
+
+The web UI displays system stats (total jobs, files, success rate) and system storage usage.
+These are fetched once when the page loads, but they do not automatically refresh while jobs are running or completing.
+
+Add an auto-refresh mechanism for the stats and storage usage, matching the interval used for checking job status (which updates every 2 seconds).

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -432,8 +432,6 @@ export function renderApp(root) {
     if (autoRefreshToggle && autoRefreshToggle.checked) {
       pollInterval = setInterval(() => {
         fetchJobs();
-        updateStorageUsage();
-        updateJobStats();
       }, 5000);
     }
   }
@@ -509,6 +507,11 @@ export function renderApp(root) {
         updateProgress(jobId);
       }
     });
+
+    if (autoRefreshToggle && autoRefreshToggle.checked) {
+      updateStorageUsage();
+      updateJobStats();
+    }
   }, 2000);
 
   form.addEventListener("submit", async (event) => {

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -59,6 +59,64 @@ describe("renderApp", () => {
     cleanup();
   });
 
+  it("polls api endpoints at correct intervals when auto-refresh is enabled", async () => {
+    vi.useFakeTimers();
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"><input type="checkbox" id="auto-refresh-toggle" checked /></div>', {
+      url: "http://localhost",
+    });
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    const root = document.getElementById("root");
+
+    const fetchMock = vi.fn((url) => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([])
+      });
+    });
+    global.fetch = fetchMock;
+
+    const cleanup = renderApp(root);
+
+    // Initial calls
+    expect(fetchMock).toHaveBeenCalledWith("/api/jobs");
+    expect(fetchMock).toHaveBeenCalledWith("/api/system/storage");
+    expect(fetchMock).toHaveBeenCalledWith("/api/stats");
+
+    fetchMock.mockClear();
+
+    // Advance by 2 seconds
+    vi.advanceTimersByTime(2000);
+
+    // progressPollInterval triggered
+    expect(fetchMock).toHaveBeenCalledWith("/api/system/storage");
+    expect(fetchMock).toHaveBeenCalledWith("/api/stats");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/jobs");
+
+    fetchMock.mockClear();
+
+    // Advance by 2 seconds (total 4)
+    vi.advanceTimersByTime(2000);
+    expect(fetchMock).toHaveBeenCalledWith("/api/system/storage");
+    expect(fetchMock).toHaveBeenCalledWith("/api/stats");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/jobs");
+
+    fetchMock.mockClear();
+
+    // Advance by 1 second (total 5)
+    vi.advanceTimersByTime(1000);
+    // pollInterval triggered
+    expect(fetchMock).toHaveBeenCalledWith("/api/jobs");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/system/storage");
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/stats");
+
+    cleanup();
+    vi.useRealTimers();
+  });
+
   it("updates the storage progress bar correctly", async () => {
     const dom = new JSDOM('<!DOCTYPE html><div id="root"></div>', {
       url: "http://localhost",


### PR DESCRIPTION
Moved `updateStorageUsage` and `updateJobStats` to the 2-second `progressPollInterval` from the 5-second `pollInterval` so stats and storage update smoothly while jobs process, meeting the backlog requirement.

Also updated Vitest tests with `vi.useFakeTimers` to verify the new interval behaviour without flakiness.

---
*PR created automatically by Jules for task [2987862186387601435](https://jules.google.com/task/2987862186387601435) started by @jjgroenendijk*