### PR TITLE
feat: Hide clear input button when input is empty

### DIFF
--- a/docs/backlog/closed/025_add_clear_input_button_visibility_toggle.md
+++ b/docs/backlog/closed/025_add_clear_input_button_visibility_toggle.md
@@ -1,0 +1,12 @@
+# 025 Toggle Clear Input button visibility
+
+## Goal
+Make the "Clear input" button visible only when there is text in the input field.
+
+## Why
+Currently the "Clear input" button is always visible. It would be cleaner UI to only show it when there is actually something to clear.
+
+## Status
+- [x] Implement the feature in frontend.
+- [x] Add/update tests.
+- [x] Verify locally and move this item to `docs/backlog/closed/`.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -151,7 +151,7 @@ export function renderApp(root) {
               required
               rows="3"
             ></textarea>
-            <button type="button" id="clear-input-btn" class="clear-history-btn">Clear input</button>
+            <button type="button" id="clear-input-btn" class="clear-history-btn" style="display: none;">Clear input</button>
             <button type="submit">Queue</button>
           </div>
           <p class="hint" id="queue-feedback">Tracks, albums, and playlists will run through the SpotiFLAC module.</p>
@@ -244,11 +244,22 @@ export function renderApp(root) {
   const sortSelect = root.querySelector("#job-sort-select");
   const clearInputBtn = root.querySelector("#clear-input-btn");
 
+  if (input && clearInputBtn) {
+    input.addEventListener("input", () => {
+      if (input.value.length > 0) {
+        clearInputBtn.style.display = "inline-block";
+      } else {
+        clearInputBtn.style.display = "none";
+      }
+    });
+  }
+
   if (clearInputBtn) {
     clearInputBtn.addEventListener("click", () => {
       input.value = "";
       feedback.textContent = "Tracks, albums, and playlists will run through the SpotiFLAC module.";
       feedback.dataset.state = "";
+      clearInputBtn.style.display = "none";
     });
   }
 
@@ -539,6 +550,9 @@ export function renderApp(root) {
 
     // Clear the text input immediately upon submitting
     input.value = "";
+    if (clearInputBtn) {
+      clearInputBtn.style.display = "none";
+    }
 
     try {
       const requests = urls.map(url =>

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1179,13 +1179,18 @@ test("can clear input field manually", async ({ page }) => {
   await page.goto("/");
 
   const input = page.locator("#spotify-url");
+  const clearBtn = page.locator("#clear-input-btn");
+
+  await expect(clearBtn).toBeHidden();
+
   await input.fill("https://open.spotify.com/track/123");
   await expect(input).toHaveValue("https://open.spotify.com/track/123");
+  await expect(clearBtn).toBeVisible();
 
-  const clearBtn = page.locator("#clear-input-btn");
   await clearBtn.click();
 
   await expect(input).toHaveValue("");
+  await expect(clearBtn).toBeHidden();
 
   const feedback = page.locator("#queue-feedback");
   await expect(feedback).toContainText("Tracks, albums, and playlists will run through the SpotiFLAC module.");


### PR DESCRIPTION
This PR implements a new UI improvement that toggles the visibility of the 'Clear input' button based on the presence of text in the Spotify URL input field.

**Changes:**
- Modified `website/src/app.js` to listen to input events and toggle the button display.
- Added an initial state of `display: none` for the clear button in the HTML logic.
- Updated Playwright tests (`website/tests/web-ui.spec.js`) to test the visibility state transitions.
- Included the tracking document `docs/backlog/closed/025_add_clear_input_button_visibility_toggle.md`.

All tests pass, code is formatted, and visual changes have been verified.

---
*PR created automatically by Jules for task [11943420068737235302](https://jules.google.com/task/11943420068737235302) started by @jjgroenendijk*