### PR TITLE
Add Playwright test for individual job retry and close backlog item

### DIFF
--- a/docs/backlog/closed/018_retry_failed_jobs.md
+++ b/docs/backlog/closed/018_retry_failed_jobs.md
@@ -1,0 +1,17 @@
+# Add "Retry" functionality for failed jobs in SpotiFLAC Web UI
+
+**Goal**: Allow users to quickly retry failed jobs directly from the SpotiFLAC web UI's job history.
+
+Currently, if a job fails due to network issues, rate limiting, or transient errors, the user has to manually copy the original Spotify URL and submit it as a new job again. We should add a "Retry" button to failed jobs in the history list.
+
+### Requirements:
+1. **Frontend UI**:
+   - Add a "Retry" button to the job card of any job with a status of "Failed".
+   - The button should trigger a new API request to queue the original URL.
+   - Upon successful queueing, the UI should ideally show some feedback or simply rely on the auto-refresh to pick up the new queued job.
+
+2. **Backend API**:
+   - The existing `POST /api/jobs` endpoint takes a JSON payload `{"url": "..."}`. We can reuse this endpoint from the frontend by extracting the URL from the failed job's data.
+
+3. **Testing**:
+   - Add/update Playwright tests to cover clicking the Retry button on a failed job and verifying that a new job request is made.

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1195,3 +1195,53 @@ test("can clear input field manually", async ({ page }) => {
   const feedback = page.locator("#queue-feedback");
   await expect(feedback).toContainText("Tracks, albums, and playlists will run through the SpotiFLAC module.");
 });
+
+test('can retry an individual failed job from its card', async ({ page }) => {
+  let retryCalled = false;
+  let retriedUrl = '';
+
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-failed-single',
+            url: 'https://open.spotify.com/track/failed-single',
+            status: 'Failed',
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: 'Single job error'
+          }
+        ])
+      });
+    } else if (route.request().method() === 'POST') {
+      retryCalled = true;
+      const postData = JSON.parse(route.request().postData() || '{}');
+      retriedUrl = postData.url;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ job_id: 'new-job-id-single' })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  const jobCard = page.locator('.job-card[data-job-id="job-failed-single"]');
+  await expect(jobCard).toBeVisible();
+
+  const retryBtn = jobCard.locator('.retry-job-btn');
+  await expect(retryBtn).toBeVisible();
+
+  const requestPromise = page.waitForRequest('/api/jobs');
+  await retryBtn.click();
+  await requestPromise;
+
+  expect(retryCalled).toBe(true);
+  expect(retriedUrl).toBe('https://open.spotify.com/track/failed-single');
+});


### PR DESCRIPTION
Adds the missing Playwright test to verify the individual retry button for failed jobs in the SpotiFLAC web UI, fulfilling the backlog item requirements. The frontend functionality already existed in the codebase.

---
*PR created automatically by Jules for task [4644940042345319014](https://jules.google.com/task/4644940042345319014) started by @jjgroenendijk*