### PR TITLE
feat: add clear button to job search input

### DIFF
--- a/docs/backlog/closed/issue-1-clear-input.md
+++ b/docs/backlog/closed/issue-1-clear-input.md
@@ -1,0 +1,10 @@
+# Backlog Item: Add "Clear" button for search input
+
+## Description
+The search input (`#job-search-input`) currently has no easy way to clear it. A small "Clear" button or 'x' icon should be added next to or inside the search input to quickly reset the filter.
+
+## Requirements
+- Add a clear button for the `#job-search-input`.
+- The button should clear the search input's value and trigger the filter update (showing all jobs again).
+- The button should only be visible when there is text in the search input.
+- Write a Playwright test to verify the functionality.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -186,6 +186,7 @@ export function renderApp(root) {
           <h2>Recent jobs</h2>
           <div style="display: flex; gap: 8px; align-items: center;">
             <input type="text" id="job-search-input" placeholder="Search URL or ID..." class="job-search-input" aria-label="Search jobs" />
+            <button type="button" id="clear-search-btn" class="clear-search-btn" style="display: none;" aria-label="Clear search">X</button>
             <select id="job-sort-select" class="job-status-filter clear-history-btn" aria-label="Sort jobs">
               <option value="newest">Newest First</option>
               <option value="oldest">Oldest First</option>
@@ -241,6 +242,7 @@ export function renderApp(root) {
   const typeFilter = root.querySelector("#job-type-filter");
   const statusFilter = root.querySelector("#job-status-filter");
   const searchInput = root.querySelector("#job-search-input");
+  const clearSearchBtn = root.querySelector("#clear-search-btn");
   const sortSelect = root.querySelector("#job-sort-select");
   const clearInputBtn = root.querySelector("#clear-input-btn");
 
@@ -428,8 +430,21 @@ export function renderApp(root) {
   if (searchInput) {
     let debounceTimer;
     searchInput.addEventListener("input", () => {
+      if (clearSearchBtn) {
+        clearSearchBtn.style.display = searchInput.value.length > 0 ? "inline-block" : "none";
+      }
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(fetchJobs, 300);
+    });
+  }
+
+  if (clearSearchBtn) {
+    clearSearchBtn.addEventListener("click", () => {
+      if (searchInput) {
+        searchInput.value = "";
+      }
+      clearSearchBtn.style.display = "none";
+      fetchJobs();
     });
   }
 

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -614,6 +614,26 @@ button:active {
   color: var(--text-tertiary);
 }
 
+.clear-search-btn {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  padding: 6px 12px;
+  margin-left: -35px;
+  border-radius: 0 8px 8px 0;
+  border-left: none;
+  z-index: 1;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.clear-search-btn:hover {
+  background: var(--glass-bg-hover);
+  border-color: var(--glass-border);
+}
+
 .clear-history-btn {
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);

--- a/website/tests/search-clear.spec.js
+++ b/website/tests/search-clear.spec.js
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  // Mock the /api/jobs GET request using wildcard pattern
+  await page.route("**/api/jobs*", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "job-123",
+            url: "https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX",
+            status: "Completed",
+            created_at: new Date().toISOString(),
+            files: 10,
+            error_log: null
+          },
+          {
+            id: "job-456",
+            url: "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC",
+            status: "Queued",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/");
+});
+
+test("shows clear search button when typing and clears input when clicked", async ({ page }) => {
+  const searchInput = page.locator("#job-search-input");
+  const clearSearchBtn = page.locator("#clear-search-btn");
+
+  // Ensure button is initially hidden
+  await expect(clearSearchBtn).not.toBeVisible();
+
+  // Type into search input
+  await searchInput.fill("job-123");
+
+  // Wait for fetchJobs debounce
+  await page.waitForTimeout(350);
+
+  // Verify button becomes visible
+  await expect(clearSearchBtn).toBeVisible();
+
+  // Verify jobs list filters based on search
+  await expect(page.locator('.job-card')).toHaveCount(1);
+  await expect(page.locator('.job-card').first()).toHaveAttribute("data-job-id", "job-123");
+
+  // Click the clear button
+  await clearSearchBtn.click();
+
+  // Wait for fetchJobs
+  await page.waitForTimeout(350);
+
+  // Verify the input is cleared
+  await expect(searchInput).toHaveValue("");
+
+  // Verify button becomes hidden again
+  await expect(clearSearchBtn).not.toBeVisible();
+
+  // Verify jobs list resets
+  await expect(page.locator('.job-card')).toHaveCount(2);
+});


### PR DESCRIPTION
Adds a functional clear button to quickly reset search inputs. The button is only visible when text is actively present in the search field.

---
*PR created automatically by Jules for task [13141075396747792932](https://jules.google.com/task/13141075396747792932) started by @jjgroenendijk*