### PR TITLE
feat: Add "Cancel all queued jobs" functionality

### DIFF
--- a/docs/backlog/closed/026_cancel_all_queued.md
+++ b/docs/backlog/closed/026_cancel_all_queued.md
@@ -1,0 +1,8 @@
+# 026 Cancel all queued jobs
+
+## Goal
+Add a button to cancel all queued jobs at once, similar to "Clear queued", but instead of clearing them from history, it marks them as Cancelled.
+
+## Context
+Currently, users can cancel individual jobs, or clear all queued jobs from history.
+Adding a "Cancel all queued" button provides a way to stop jobs from running without losing their records in the history.

--- a/server.py
+++ b/server.py
@@ -626,6 +626,29 @@ async def clear_failed_history():
 
     return {"status": "success", "cleared": len(cleared_jobs)}
 
+@app.post("/api/jobs/cancel-queued")
+async def cancel_all_queued():
+    history = []
+    cancelled_count = 0
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        new_history = []
+
+        for job in history:
+            if job.get("status") == "Queued":
+                job["status"] = "Cancelled"
+                job["completed_at"] = datetime.now(timezone.utc).isoformat()
+                cancelled_count += 1
+            new_history.append(job)
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(new_history, f, indent=2)
+
+    return {"status": "success", "cancelled": cancelled_count}
+
 @app.delete("/api/jobs/{job_id}")
 async def cancel_job(job_id: str):
     history = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,6 +62,47 @@ def test_cancel_nonexistent_job():
     response = client.delete("/api/jobs/not-a-real-id")
     assert response.status_code == 404
 
+def test_cancel_all_queued_jobs():
+    import json
+
+    # Write some dummy jobs directly to history file
+    dummy_history = [
+        {"id": "job-q1", "url": "https://open.spotify.com/track/abc", "status": "Queued"},
+        {"id": "job-q2", "url": "https://open.spotify.com/track/def", "status": "Completed"},
+        {"id": "job-q3", "url": "https://open.spotify.com/track/ghi", "status": "Queued"},
+        {"id": "job-q4", "url": "https://open.spotify.com/track/jkl", "status": "Running"}
+    ]
+    with open(HISTORY_FILE, "w") as f:
+        json.dump(dummy_history, f)
+
+    response = client.post("/api/jobs/cancel-queued")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["cancelled"] == 2
+
+    # Verify status in history
+    response = client.get("/api/jobs")
+    jobs = response.json()
+
+    job_q1 = next((j for j in jobs if j["id"] == "job-q1"), None)
+    assert job_q1 is not None
+    assert job_q1["status"] == "Cancelled"
+    assert "completed_at" in job_q1
+
+    job_q2 = next((j for j in jobs if j["id"] == "job-q2"), None)
+    assert job_q2 is not None
+    assert job_q2["status"] == "Completed"
+
+    job_q3 = next((j for j in jobs if j["id"] == "job-q3"), None)
+    assert job_q3 is not None
+    assert job_q3["status"] == "Cancelled"
+    assert "completed_at" in job_q3
+
+    job_q4 = next((j for j in jobs if j["id"] == "job-q4"), None)
+    assert job_q4 is not None
+    assert job_q4["status"] == "Running"
+
 def test_clear_failed_history():
     import json
 

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -222,6 +222,7 @@ export function renderApp(root) {
             <button type="button" id="clear-running-btn" class="clear-history-btn" style="border-color: rgba(59, 130, 246, 0.5); color: #3b82f6;">Clear running</button>
             <button type="button" id="retry-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Retry cancelled</button>
             <button type="button" id="clear-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Clear cancelled</button>
+            <button type="button" id="cancel-all-queued-btn" class="clear-history-btn" style="border-color: rgba(249, 115, 22, 0.5); color: #f97316;">Cancel all queued</button>
             <button type="button" id="clear-queued-btn" class="clear-history-btn" style="border-color: rgba(249, 115, 22, 0.5); color: #f97316;">Clear queued</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
             <a href="/api/history/export" id="export-history-btn" class="clear-history-btn" download style="text-decoration: none; border-color: rgba(139, 92, 246, 0.5); color: #8b5cf6;">Export JSON</a>
@@ -887,6 +888,27 @@ export function renderApp(root) {
       } finally {
         clearCancelledBtn.disabled = false;
         clearCancelledBtn.textContent = "Clear cancelled";
+      }
+    });
+  }
+
+  const cancelAllQueuedBtn = root.querySelector("#cancel-all-queued-btn");
+  if (cancelAllQueuedBtn) {
+    cancelAllQueuedBtn.addEventListener("click", async () => {
+      cancelAllQueuedBtn.disabled = true;
+      cancelAllQueuedBtn.textContent = "Cancelling...";
+      try {
+        const response = await fetch("/api/jobs/cancel-queued", { method: "POST" });
+        if (response.ok) {
+          fetchJobs();
+        } else {
+          console.error("Failed to cancel queued jobs");
+        }
+      } catch (error) {
+        console.error("Error cancelling queued jobs:", error);
+      } finally {
+        cancelAllQueuedBtn.disabled = false;
+        cancelAllQueuedBtn.textContent = "Cancel all queued";
       }
     });
   }

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1019,6 +1019,59 @@ test("filters jobs by type", async ({ page }) => {
   await expect(page.locator('.job-card')).toHaveCount(3);
 });
 
+test('cancel all queued jobs', async ({ page }) => {
+  let cancelCalled = false;
+
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-queued',
+            url: 'https://open.spotify.com/track/queued-track',
+            status: 'Queued',
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ])
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.route('/api/jobs/cancel-queued', async (route) => {
+    if (route.request().method() === 'POST') {
+      cancelCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'success', cancelled: 1 })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto('/');
+
+  // Wait for the job card to load
+  await expect(page.locator('.job-card')).toHaveCount(1);
+
+  const cancelAllQueuedBtn = page.locator('#cancel-all-queued-btn');
+  await expect(cancelAllQueuedBtn).toBeVisible();
+
+  await cancelAllQueuedBtn.click();
+
+  // Give it a moment to call the API
+  await page.waitForTimeout(500);
+
+  expect(cancelCalled).toBe(true);
+});
+
 test('retry all cancelled jobs', async ({ page }) => {
   let retryCalled = false;
   let retriedUrl = '';


### PR DESCRIPTION
Implements a new feature to bulk cancel all currently queued jobs without removing them from history. Includes comprehensive testing and fully completes open backlog item 026.

---
*PR created automatically by Jules for task [15471753781468927572](https://jules.google.com/task/15471753781468927572) started by @jjgroenendijk*