### PR TITLE
feat: add confirmation dialog for cancel all queued button

### DIFF
--- a/docs/backlog/closed/027-confirm-cancel-all-queued.md
+++ b/docs/backlog/closed/027-confirm-cancel-all-queued.md
@@ -1,0 +1,10 @@
+# Confirm Cancel All Queued Jobs
+
+## Requirement
+The web UI has a "Cancel all queued" button. Clicking this button immediately cancels all queued jobs. This can be destructive and happen accidentally.
+We need to add a confirmation dialog before cancelling all queued jobs to prevent accidental clicks.
+
+## Tasks
+- Add a `window.confirm` dialog to the `#cancel-all-queued-btn` click event listener in `website/src/app.js` with the message "Are you sure you want to cancel all queued jobs? This cannot be undone.".
+- If the user clicks "Cancel" (dismisses the dialog), do not execute the API request.
+- Add a Playwright UI test to verify the confirmation dialog appears and that the API request is made when accepted.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -895,6 +895,9 @@ export function renderApp(root) {
   const cancelAllQueuedBtn = root.querySelector("#cancel-all-queued-btn");
   if (cancelAllQueuedBtn) {
     cancelAllQueuedBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to cancel all queued jobs? This cannot be undone.")) {
+        return;
+      }
       cancelAllQueuedBtn.disabled = true;
       cancelAllQueuedBtn.textContent = "Cancelling...";
       try {

--- a/website/tests/cancel-all-queued-confirm.spec.js
+++ b/website/tests/cancel-all-queued-confirm.spec.js
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  // Mock the /api/jobs GET request using wildcard pattern
+  await page.route("**/api/jobs*", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "job-123",
+            url: "https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX",
+            status: "Queued",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto("/");
+});
+
+test("shows confirmation dialog and cancels all queued jobs when accepted", async ({ page }) => {
+  const cancelAllQueuedBtn = page.locator("#cancel-all-queued-btn");
+
+  await expect(cancelAllQueuedBtn).toBeVisible();
+
+  let dialogTriggered = false;
+  let apiCallMade = false;
+
+  // Handle dialog: automatically accept it
+  page.on("dialog", async (dialog) => {
+    expect(dialog.message()).toBe("Are you sure you want to cancel all queued jobs? This cannot be undone.");
+    dialogTriggered = true;
+    await dialog.accept();
+  });
+
+  // Mock the cancel API call
+  await page.route("**/api/jobs/cancel-queued", async (route) => {
+    if (route.request().method() === "POST") {
+      apiCallMade = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "success", cancelled: 1 }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await cancelAllQueuedBtn.click();
+
+  // Give the UI time to process the click and the fetch request
+  await page.waitForTimeout(100);
+
+  expect(dialogTriggered).toBe(true);
+  expect(apiCallMade).toBe(true);
+});
+
+test("shows confirmation dialog and does not cancel all queued jobs when dismissed", async ({ page }) => {
+  const cancelAllQueuedBtn = page.locator("#cancel-all-queued-btn");
+
+  await expect(cancelAllQueuedBtn).toBeVisible();
+
+  let dialogTriggered = false;
+  let apiCallMade = false;
+
+  // Handle dialog: automatically dismiss it
+  page.on("dialog", async (dialog) => {
+    expect(dialog.message()).toBe("Are you sure you want to cancel all queued jobs? This cannot be undone.");
+    dialogTriggered = true;
+    await dialog.dismiss();
+  });
+
+  // Intercept the cancel API call to ensure it's NOT made
+  await page.route("**/api/jobs/cancel-queued", async (route) => {
+    if (route.request().method() === "POST") {
+      apiCallMade = true;
+      await route.abort();
+    } else {
+      await route.continue();
+    }
+  });
+
+  await cancelAllQueuedBtn.click();
+
+  // Give the UI time to process
+  await page.waitForTimeout(100);
+
+  expect(dialogTriggered).toBe(true);
+  expect(apiCallMade).toBe(false);
+});

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1064,6 +1064,10 @@ test('cancel all queued jobs', async ({ page }) => {
   const cancelAllQueuedBtn = page.locator('#cancel-all-queued-btn');
   await expect(cancelAllQueuedBtn).toBeVisible();
 
+  page.on('dialog', async (dialog) => {
+    await dialog.accept();
+  });
+
   await cancelAllQueuedBtn.click();
 
   // Give it a moment to call the API


### PR DESCRIPTION
Adds a confirmation dialog to the "Cancel all queued" button to prevent destructive accidental clicks, and implements test coverage for both accepting and dismissing the dialog.

---
*PR created automatically by Jules for task [41640277460052036](https://jules.google.com/task/41640277460052036) started by @jjgroenendijk*