### PR TITLE
feat: add health check endpoint

### DIFF
--- a/docs/backlog/closed/001-setup-health-endpoint.md
+++ b/docs/backlog/closed/001-setup-health-endpoint.md
@@ -1,0 +1,8 @@
+# Setup health endpoint
+
+## Context
+As part of the SpotiFLAC web UI product direction (requirement 3), we need a backend to orchestrate the `SpotiFLAC` Python module and serve the web UI.
+
+## Requirements
+1. Add an API endpoint for health checking (`/api/health`) to `server.py` that returns `{"status": "ok"}`.
+2. Add test for the backend health checking endpoint to `tests/test_server.py`.

--- a/server.py
+++ b/server.py
@@ -733,6 +733,10 @@ def _calculate_stats():
 async def get_stats():
     return await asyncio.to_thread(_calculate_stats)
 
+@app.get("/api/health")
+async def get_health():
+    return {"status": "ok"}
+
 @app.get("/api/system/storage")
 def get_system_storage():
     try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -598,3 +598,8 @@ def test_download_all_logs_not_found(mock_logs_dir, tmp_path):
     response = client.get("/api/history/logs/download")
     assert response.status_code == 404
     assert response.json()["detail"] == "No logs found"
+
+def test_health_endpoint():
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
Added a `/api/health` endpoint to the backend to fulfill requirement #3 for a health-checking route.

- Created `@app.get("/api/health")` in `server.py`
- Added `test_health_endpoint` in `tests/test_server.py`
- Moved corresponding backlog item to closed.

---
*PR created automatically by Jules for task [9452893998672776946](https://jules.google.com/task/9452893998672776946) started by @jjgroenendijk*