### PR TITLE
feat: display storage percentage in web UI

### DIFF
--- a/docs/backlog/closed/019_add_storage_display.md
+++ b/docs/backlog/closed/019_add_storage_display.md
@@ -1,0 +1,9 @@
+# 019 Add storage percentage display
+
+## Goal
+Show the current storage usage percentage inside the SpotiFLAC web UI so users know exactly how full their `/data` volume is without needing to hover over the bar or calculate it manually.
+
+## Implementation details
+- Update `website/src/app.js`'s `updateStorageUsage()` function.
+- Find or create an element next to or inside the storage progress section to show the calculated percentage as text (e.g., `42% used`).
+- Add a Playwright test if necessary to assert its presence and format.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -163,7 +163,10 @@ export function renderApp(root) {
           <div class="storage-progress-bar-bg" aria-hidden="true" style="margin-top: 8px; margin-bottom: 8px;">
             <div class="storage-progress-bar-fill" id="storage-progress-fill" style="width: 0%;"></div>
           </div>
-          <p id="storage-usage-text">Job history, logs, and produced files will persist outside the container.</p>
+          <p style="margin: 0;">
+            <span id="storage-usage-text">Job history, logs, and produced files will persist outside the container.</span>
+            <span id="storage-percentage-text" style="color: var(--text-secondary); font-size: 0.85em; margin-left: 4px;"></span>
+          </p>
           <div id="job-stats-container" style="margin-top: 16px; font-size: 0.85rem; color: var(--text-secondary); display: grid; grid-template-columns: 1fr 1fr; gap: 8px;">
             <div>
               <strong style="color: var(--text-primary);">Total Jobs</strong>
@@ -324,17 +327,26 @@ export function renderApp(root) {
       if (response.ok) {
         const data = await response.json();
         const textElement = root.querySelector("#storage-usage-text");
+        const percentageElement = root.querySelector("#storage-percentage-text");
+
         if (textElement && data.free !== undefined && data.total !== undefined) {
           textElement.textContent = `${formatBytes(data.free)} free of ${formatBytes(data.total)}`;
 
-          const fillElement = root.querySelector("#storage-progress-fill");
-          if (fillElement && data.total > 0) {
+          if (data.total > 0) {
             const usedPercentage = ((data.total - data.free) / data.total) * 100;
-            fillElement.style.width = `${Math.min(100, Math.max(0, usedPercentage))}%`;
-            if (usedPercentage > 90) {
-              fillElement.classList.add("danger");
-            } else {
-              fillElement.classList.remove("danger");
+
+            if (percentageElement) {
+                percentageElement.textContent = `(${Math.round(usedPercentage)}% used)`;
+            }
+
+            const fillElement = root.querySelector("#storage-progress-fill");
+            if (fillElement) {
+              fillElement.style.width = `${Math.min(100, Math.max(0, usedPercentage))}%`;
+              if (usedPercentage > 90) {
+                fillElement.classList.add("danger");
+              } else {
+                fillElement.classList.remove("danger");
+              }
             }
           }
         }

--- a/website/tests/storage-percentage.spec.js
+++ b/website/tests/storage-percentage.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Storage Percentage Display', () => {
+  test('should display storage percentage calculated correctly', async ({ page }) => {
+    // Intercept the storage endpoint to return a mocked response
+    await page.route('/api/system/storage', async (route) => {
+      // Return 50% storage used
+      const total = 1000000;
+      const free = 500000;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total, free, used: total - free }),
+      });
+    });
+
+    // Mock jobs endpoint to avoid errors
+    await page.route('/api/jobs', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    // Navigate to the app
+    await page.goto('/');
+
+    // Check that the storage usage text is updated
+    await expect(page.locator('#storage-usage-text')).toContainText('488.3 KB free of 976.6 KB');
+
+    // Check that the storage percentage text displays the correct percentage
+    await expect(page.locator('#storage-percentage-text')).toBeVisible();
+    await expect(page.locator('#storage-percentage-text')).toContainText('(50% used)');
+  });
+
+  test('should round storage percentage appropriately', async ({ page }) => {
+    await page.route('/api/system/storage', async (route) => {
+      // Total 100, Free 33 -> Used 67%
+      const total = 1000;
+      const free = 330;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total, free, used: total - free }),
+      });
+    });
+
+    await page.route('/api/jobs', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto('/');
+
+    await expect(page.locator('#storage-percentage-text')).toBeVisible();
+    await expect(page.locator('#storage-percentage-text')).toContainText('(67% used)');
+  });
+});


### PR DESCRIPTION
- Modified `website/src/app.js` to calculate and render the percentage of used space for the `/data` volume.
- Added `website/tests/storage-percentage.spec.js` Playwright test suite to mock the endpoint and assert correct UI calculation formatting.
- Moved `docs/backlog/open/019_add_storage_display.md` to closed folder after completion.
- Ensured all frontend tests and backend checks pass.

---
*PR created automatically by Jules for task [12325361210727789691](https://jules.google.com/task/12325361210727789691) started by @jjgroenendijk*