### PR TITLE
feat: add confirmation dialog for single job cancellation

### DIFF
--- a/docs/backlog/open/028-confirm-cancel-job.md
+++ b/docs/backlog/open/028-confirm-cancel-job.md
@@ -1,0 +1,10 @@
+# Confirm Cancel Job
+
+## Requirement
+The web UI has a "Cancel" button for individual queued/running jobs. Clicking this button immediately cancels the job. This can be destructive and happen accidentally.
+We need to add a confirmation dialog before cancelling a single job to prevent accidental clicks.
+
+## Tasks
+- Add a `window.confirm` dialog to the `#cancel-job-btn` click event listener in `website/src/app.js` with the message "Are you sure you want to cancel this job?".
+- If the user clicks "Cancel" (dismisses the dialog), do not execute the API request.
+- Add a Playwright UI test to verify the confirmation dialog appears and that the API request is made when accepted.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -750,6 +750,10 @@ export function renderApp(root) {
       const jobId = event.target.dataset.jobId;
       if (!jobId) return;
 
+      if (!window.confirm("Are you sure you want to cancel this job?")) {
+        return;
+      }
+
       event.target.disabled = true;
       event.target.textContent = "Cancelling...";
 

--- a/website/tests/cancel-job-confirm.spec.js
+++ b/website/tests/cancel-job-confirm.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+test("does not cancel job when confirmation is dismissed", async ({ page }) => {
+  let deleteApiCalled = false;
+  let dialogTriggered = false;
+
+  // Mock initial GET to show one queued job
+  await page.route("/api/jobs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "125",
+            url: "https://open.spotify.com/track/456",
+            status: "Queued",
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ]),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  // Handle dialog: dismiss it
+  page.on("dialog", async (dialog) => {
+    expect(dialog.message()).toBe("Are you sure you want to cancel this job?");
+    dialogTriggered = true;
+    await dialog.dismiss();
+  });
+
+  // Route intercept for DELETE api to verify it's not called
+  await page.route("**/api/jobs/*", async (route) => {
+    if (route.request().method() === "DELETE") {
+      deleteApiCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "success" })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.goto("/");
+
+  const cancelBtn = page.getByRole("button", { name: "Cancel", exact: true });
+  await expect(cancelBtn).toBeVisible();
+
+  await cancelBtn.click();
+
+  // Wait a little bit to ensure API is not called
+  await page.waitForTimeout(500);
+
+  expect(dialogTriggered).toBe(true);
+  expect(deleteApiCalled).toBe(false);
+
+  // Button should remain in "Cancel" state
+  await expect(cancelBtn).toHaveText("Cancel");
+});

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -238,6 +238,8 @@ test("shows cancel button for queued job and handles click", async ({ page }) =>
   const cancelBtn = page.getByRole("button", { name: "Cancel", exact: true });
   await expect(cancelBtn).toBeVisible();
 
+  page.once("dialog", dialog => dialog.accept());
+
   await cancelBtn.click();
 
   // Since we don't mock the subsequent GET /api/jobs in a way that changes state


### PR DESCRIPTION
This PR introduces a confirmation dialog to the individual "Cancel" button for queued/running jobs. This prevents accidental job cancellations by requiring the user to explicitly accept a `window.confirm` prompt.

Key changes:
- `website/src/app.js`: Added the confirmation check to the click listener.
- `website/tests/web-ui.spec.js`: Updated existing tests to intercept and accept the dialog.
- `website/tests/cancel-job-confirm.spec.js`: Added a new test validating the abort logic.

---
*PR created automatically by Jules for task [14694587982418118250](https://jules.google.com/task/14694587982418118250) started by @jjgroenendijk*