### PR TITLE
Add 'Copy Job ID' button to Job Cards

### DIFF
--- a/docs/backlog/closed/029-copy-job-id.md
+++ b/docs/backlog/closed/029-copy-job-id.md
@@ -1,0 +1,5 @@
+# Title: Add 'Copy Job ID' button to Job Cards
+# Problem:
+Homelab users who self-host SpotiFLAC have the `/data` volume mounted locally on their servers. When a job completes or fails, they might want to inspect the raw files or logs directly on the server filesystem. Currently, the UI does not display the internal Job ID, which corresponds to the folder name in the `/data` volume. This makes server-side debugging or file management difficult.
+# Solution:
+Display the Job ID in the job card UI and provide a 'Copy Job ID' button. This will copy the UUID to the user's clipboard, making it trivial to find the corresponding folder in their homelab environment (e.g., `/data/UUID`).

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -85,6 +85,7 @@ function renderJob(job) {
           <button type="button" class="copy-url-btn" data-job-url="${escapeHtml(job.url)}" style="font-size: 0.75rem; padding: 2px 6px; margin-left: 8px; vertical-align: middle; border: 1px solid var(--border-color); background: transparent; color: var(--text-secondary); cursor: pointer; border-radius: 4px;">Copy</button>
         </p>
         <p class="job-source">Started: ${new Date(job.created_at).toLocaleString()}</p>
+        <p class="job-id-display" style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 4px;">ID: ${escapeHtml(job.id)} <button type="button" class="copy-job-id-btn" data-job-id="${escapeHtml(job.id)}" style="font-size: 0.75rem; padding: 2px 6px; margin-left: 8px; vertical-align: middle; border: 1px solid var(--border-color); background: transparent; color: var(--text-secondary); cursor: pointer; border-radius: 4px;">Copy ID</button></p>
         ${completedAtHtml}
       </div>
       <div class="job-meta">
@@ -866,6 +867,26 @@ export function renderApp(root) {
         }, 2000);
       } catch (err) {
         console.error("Failed to copy URL", err);
+      }
+    }
+
+    if (event.target.classList.contains("copy-job-id-btn")) {
+      const jobId = event.target.dataset.jobId;
+      if (!jobId) return;
+
+      try {
+        await navigator.clipboard.writeText(jobId);
+        const btn = event.target;
+        const originalText = btn.textContent;
+        btn.textContent = "Copied!";
+        btn.disabled = true;
+
+        setTimeout(() => {
+          btn.textContent = originalText;
+          btn.disabled = false;
+        }, 2000);
+      } catch (err) {
+        console.error("Failed to copy Job ID", err);
       }
     }
   });

--- a/website/tests/copy-job-id.spec.js
+++ b/website/tests/copy-job-id.spec.js
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Copy Job ID Feature', () => {
+  test('should display job ID and copy to clipboard on button click', async ({ page, context }) => {
+    // Grant clipboard permissions
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const testJobId = 'test-job-id-12345';
+
+    // Mock the endpoints
+    await page.route('**/api/stats*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total_jobs: 1, total_files: 0, success_rate: 100 })
+      });
+    });
+
+    await page.route('**/api/jobs*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: testJobId,
+            url: 'https://open.spotify.com/track/123',
+            status: 'Completed',
+            created_at: new Date().toISOString()
+          }
+        ])
+      });
+    });
+
+    await page.route('**/api/system/storage*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ total: 1000, used: 500, free: 500 })
+        });
+    });
+
+    await page.goto('/');
+
+    // Wait for the job card to appear
+    const jobCard = page.locator(`.job-card[data-job-id="${testJobId}"]`);
+    await expect(jobCard).toBeVisible();
+
+    // Verify the ID is displayed
+    const idDisplay = jobCard.locator('.job-id-display');
+    await expect(idDisplay).toBeVisible();
+    await expect(idDisplay).toContainText(`ID: ${testJobId}`);
+
+    // Verify the button exists and click it
+    const copyButton = jobCard.locator('.copy-job-id-btn');
+    await expect(copyButton).toBeVisible();
+
+    // Set a dummy value in the clipboard first to ensure it actually changes
+    await page.evaluate(() => navigator.clipboard.writeText('initial-clipboard-value'));
+
+    // Click the copy button
+    await copyButton.click();
+
+    // Verify button text changed to "Copied!"
+    await expect(copyButton).toHaveText('Copied!');
+
+    // Verify it disabled
+    await expect(copyButton).toBeDisabled();
+
+    // Read clipboard text directly in page context
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toBe(testJobId);
+  });
+});


### PR DESCRIPTION
Homelab users who self-host SpotiFLAC have the `/data` volume mounted locally on their servers. When a job completes or fails, they might want to inspect the raw files or logs directly on the server filesystem. Currently, the UI does not display the internal Job ID, which corresponds to the folder name in the `/data` volume. This makes server-side debugging or file management difficult.

This change displays the Job ID in the job card UI and provides a 'Copy ID' button. This will copy the UUID to the user's clipboard, making it trivial to find the corresponding folder in their homelab environment (e.g., `/data/UUID`).

---
*PR created automatically by Jules for task [5391050107212714584](https://jules.google.com/task/5391050107212714584) started by @jjgroenendijk*