### PR TITLE
feat: retry running jobs feature

### DIFF
--- a/docs/backlog/closed/001-retry-running-jobs.md
+++ b/docs/backlog/closed/001-retry-running-jobs.md
@@ -1,0 +1,3 @@
+# Propose New Requirement: Retry all running jobs
+
+Implement a 'Retry running jobs' feature to cancel and immediately retry jobs that might be stuck in the Running state.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -225,6 +225,7 @@ export function renderApp(root) {
             <button type="button" id="clear-completed-btn" class="clear-history-btn" style="border-color: rgba(16, 185, 129, 0.5); color: #10b981;">Clear completed</button>
             <button type="button" id="retry-failed-btn" class="clear-history-btn" style="border-color: rgba(234, 179, 8, 0.5); color: #eab308;">Retry failed</button>
             <button type="button" id="clear-failed-btn" class="clear-history-btn" style="border-color: rgba(220, 38, 38, 0.5); color: #dc2626;">Clear failed</button>
+            <button type="button" id="retry-running-btn" class="clear-history-btn" style="border-color: rgba(59, 130, 246, 0.5); color: #3b82f6;">Retry running</button>
             <button type="button" id="clear-running-btn" class="clear-history-btn" style="border-color: rgba(59, 130, 246, 0.5); color: #3b82f6;">Clear running</button>
             <button type="button" id="retry-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Retry cancelled</button>
             <button type="button" id="clear-cancelled-btn" class="clear-history-btn" style="border-color: rgba(156, 163, 175, 0.5); color: #9ca3af;">Clear cancelled</button>
@@ -1082,6 +1083,42 @@ export function renderApp(root) {
       } finally {
         retryFailedBtn.disabled = false;
         retryFailedBtn.textContent = "Retry failed";
+      }
+    });
+  }
+
+  const retryRunningBtn = root.querySelector("#retry-running-btn");
+  if (retryRunningBtn) {
+    retryRunningBtn.addEventListener("click", async () => {
+      retryRunningBtn.disabled = true;
+      retryRunningBtn.textContent = "Retrying...";
+      try {
+        const jobsResponse = await fetch("/api/jobs");
+        if (jobsResponse.ok) {
+          const jobs = await jobsResponse.json();
+          const runningJobs = jobs.filter(job => job.status === "Running");
+
+          const retryRequests = runningJobs.map(async (job) => {
+            // First delete the running job
+            await fetch(`/api/jobs/${encodeURIComponent(job.id)}`, {
+              method: "DELETE",
+            });
+            // Then re-queue it
+            return fetch("/api/jobs", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ url: job.url })
+            });
+          });
+
+          await Promise.allSettled(retryRequests);
+          fetchJobs();
+        }
+      } catch (err) {
+        console.error("Failed to retry running jobs", err);
+      } finally {
+        retryRunningBtn.disabled = false;
+        retryRunningBtn.textContent = "Retry running";
       }
     });
   }

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1388,3 +1388,77 @@ test('sorts jobs by newest and oldest', async ({ page }) => {
   // Verify the first job is now the oldest
   await expect(page.locator('.job-card').first().locator('.source-link')).toHaveText("https://open.spotify.com/track/old");
 });
+
+test('can retry all running jobs', async ({ page }) => {
+  let deleteCalled = false;
+  let retryCalled = false;
+  let retriedUrl = '';
+
+  await page.route('/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-running',
+            url: 'https://open.spotify.com/track/running-track',
+            status: 'Running',
+            created_at: new Date().toISOString(),
+            files: 0,
+            error_log: null
+          }
+        ])
+      });
+    } else if (route.request().method() === 'POST') {
+      retryCalled = true;
+      const postData = JSON.parse(route.request().postData() || '{}');
+      retriedUrl = postData.url;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ job_id: 'new-job-id' })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.route('/api/jobs/job-running', async (route) => {
+    if (route.request().method() === 'DELETE') {
+      deleteCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'success' })
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.route('/api/stats', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total_jobs: 1, total_files: 0, success_rate: 0 })
+    });
+  });
+
+  await page.goto('/');
+
+  // Wait for the job card to load
+  await expect(page.locator('.job-card')).toHaveCount(1);
+
+  const retryRunningBtn = page.locator('#retry-running-btn');
+  await expect(retryRunningBtn).toBeVisible();
+
+  await retryRunningBtn.click();
+
+  // Give it a moment to call the API
+  await page.waitForTimeout(500);
+
+  expect(deleteCalled).toBe(true);
+  expect(retryCalled).toBe(true);
+  expect(retriedUrl).toBe('https://open.spotify.com/track/running-track');
+});


### PR DESCRIPTION
Adds a 'Retry running' button and the corresponding logic to cancel and immediately retry all running jobs. Moves the related requirement file to closed backlog.

---
*PR created automatically by Jules for task [8201261257539648182](https://jules.google.com/task/8201261257539648182) started by @jjgroenendijk*