### PR TITLE
feat: Support Spotify Artist URLs

### DIFF
--- a/docs/backlog/closed/01_support_artist_urls.md
+++ b/docs/backlog/closed/01_support_artist_urls.md
@@ -1,0 +1,10 @@
+# Support Spotify Artist URLs
+
+## Description
+Currently, the SpotiFLAC web interface only accepts Spotify track, album, and playlist URLs. We should expand this functionality to also support Spotify artist URLs so users can queue up an entire artist's discography for download.
+
+## Requirements
+- Update URL validation logic in the frontend (`isSpotifyUrl` in `app.js`) to allow URLs containing `/artist/`.
+- Update placeholder text and queue feedback messages in the UI to mention "artists".
+- Add an "Artist" option to the job type filter dropdown so users can filter jobs by artist URLs.
+- Add Playwright UI tests to verify that an artist URL can be successfully queued and that the new filter option works.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -6,7 +6,7 @@ export function isSpotifyUrl(value) {
 
     return (
       host === "open.spotify.com" &&
-      ["track", "album", "playlist"].includes(parts[0]) &&
+      ["track", "album", "playlist", "artist"].includes(parts[0]) &&
       Boolean(parts[1])
     );
   } catch {
@@ -148,7 +148,7 @@ export function renderApp(root) {
             <textarea
               id="spotify-url"
               name="spotify-url"
-              placeholder="https://open.spotify.com/album/..."
+              placeholder="https://open.spotify.com/artist/..."
               autocomplete="off"
               required
               rows="3"
@@ -156,7 +156,7 @@ export function renderApp(root) {
             <button type="button" id="clear-input-btn" class="clear-history-btn" style="display: none;">Clear input</button>
             <button type="submit">Queue</button>
           </div>
-          <p class="hint" id="queue-feedback">Tracks, albums, and playlists will run through the SpotiFLAC module.</p>
+          <p class="hint" id="queue-feedback">Tracks, albums, playlists, and artists will run through the SpotiFLAC module.</p>
         </form>
 
         <aside class="storage-panel" aria-label="Storage status">
@@ -201,6 +201,7 @@ export function renderApp(root) {
               <option value="Track">Track</option>
               <option value="Album">Album</option>
               <option value="Playlist">Playlist</option>
+              <option value="Artist">Artist</option>
             </select>
             <select id="job-status-filter" class="job-status-filter clear-history-btn" aria-label="Filter jobs by status">
               <option value="All">All</option>
@@ -267,7 +268,7 @@ export function renderApp(root) {
   if (clearInputBtn) {
     clearInputBtn.addEventListener("click", () => {
       input.value = "";
-      feedback.textContent = "Tracks, albums, and playlists will run through the SpotiFLAC module.";
+      feedback.textContent = "Tracks, albums, playlists, and artists will run through the SpotiFLAC module.";
       feedback.dataset.state = "";
       clearInputBtn.style.display = "none";
     });

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -1290,7 +1290,7 @@ test("can clear input field manually", async ({ page }) => {
   await expect(clearBtn).toBeHidden();
 
   const feedback = page.locator("#queue-feedback");
-  await expect(feedback).toContainText("Tracks, albums, and playlists will run through the SpotiFLAC module.");
+  await expect(feedback).toContainText("Tracks, albums, playlists, and artists will run through the SpotiFLAC module.");
 });
 
 test('can retry an individual failed job from its card', async ({ page }) => {
@@ -1461,4 +1461,68 @@ test('can retry all running jobs', async ({ page }) => {
   expect(deleteCalled).toBe(true);
   expect(retryCalled).toBe(true);
   expect(retriedUrl).toBe('https://open.spotify.com/track/running-track');
+});
+
+test('can queue an artist URL and filter by Artist type', async ({ page }) => {
+  let requestMade = false;
+  let requestUrl = '';
+
+  await page.route('**/api/jobs*', async (route) => {
+    if (route.request().method() === 'POST') {
+      requestMade = true;
+      const body = JSON.parse(route.request().postData());
+      requestUrl = body.url;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '123',
+          url: body.url,
+          status: 'Queued',
+          created_at: new Date().toISOString(),
+          files: 0,
+          error_log: null
+        })
+      });
+    } else if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([])
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route('**/api/stats', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 })
+    });
+  });
+
+  await page.goto('/');
+
+  // Verify Artist filter option
+  const typeFilter = page.locator('#job-type-filter');
+  await expect(typeFilter).toBeVisible();
+  const options = await typeFilter.locator('option').allTextContents();
+  expect(options).toContain('Artist');
+
+  // Fill and queue artist URL
+  const artistUrl = 'https://open.spotify.com/artist/0TnOYISbd1XYRBk9myaseg';
+  await page.fill('[name="spotify-url"]', artistUrl);
+
+  // Set up request listener before clicking
+  const requestPromise = page.waitForRequest('**/api/jobs*');
+  await page.click('button[type="submit"]');
+
+  // Wait for the request to be made
+  const request = await requestPromise;
+
+  expect(request.method()).toBe('POST');
+  expect(requestMade).toBe(true);
+  expect(requestUrl).toBe(artistUrl);
 });


### PR DESCRIPTION
Expands the URL validation in the frontend to allow URLs containing `/artist/`. Adds "Artist" to the job type filter. Updates queue feedback and placeholder texts to mention artists. Adds Playwright tests to verify the functionality and correct filter options. Also moves the created backlog issue to closed.

---
*PR created automatically by Jules for task [15822143864873283806](https://jules.google.com/task/15822143864873283806) started by @jjgroenendijk*