### PR TITLE
feat: add delete all jobs button

### DIFF
--- a/docs/backlog/closed/delete-all-jobs.md
+++ b/docs/backlog/closed/delete-all-jobs.md
@@ -1,0 +1,17 @@
+# Feature: Delete All Jobs Button
+
+## Context
+Currently, users can clear jobs by status (completed, failed, running, queued, cancelled) or clear all history (which clears non-running jobs).
+We need a single button to "Delete All Jobs" that completely clears all jobs, regardless of their status (including running and queued jobs).
+It should prompt the user for confirmation before proceeding.
+
+## Requirements
+1. Add a "Delete All Jobs" button to the UI (e.g., next to the "Clear history" button).
+2. It should have a confirmation dialog ("Are you sure you want to delete all jobs, including running ones? This cannot be undone.").
+3. It should call an API endpoint (e.g., `DELETE /api/jobs/all` or combine existing clear logic) to delete everything.
+4. After deleting, it should fetch jobs to update the UI.
+5. Add a Playwright test to verify this functionality.
+
+## Technical Notes
+- The backend might need a new endpoint or the UI can call multiple endpoints if a single endpoint isn't practical.
+- A new endpoint `DELETE /api/jobs` or similar might be best to cleanly cancel/delete running processes and clear the database.

--- a/server.py
+++ b/server.py
@@ -649,6 +649,73 @@ async def cancel_all_queued():
 
     return {"status": "success", "cancelled": cancelled_count}
 
+async def _delete_all_files_background(history):
+    # This will run concurrently in the background so it doesn't block the API
+    tasks = []
+    for job in history:
+        job_id = job["id"]
+        log_file = LOGS_DIR / f"{job_id}.log"
+        log_file.unlink(missing_ok=True)
+        tasks.append(asyncio.to_thread(_delete_job_files, job_id))
+
+    if tasks:
+        await asyncio.gather(*tasks)
+
+@app.delete("/api/jobs")
+async def delete_all_jobs(background_tasks: BackgroundTasks):
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+        else:
+            history = []
+
+        # Mark queued jobs as cancelled so `run_spotiflac` exits early
+        # even if we clear history right away or later
+        for job in history:
+            if job["status"] == "Queued":
+                job["status"] = "Cancelled"
+
+        # Write it back briefly so background workers can read the "Cancelled" state
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(history, f, indent=2)
+
+        # Terminate running processes
+        for job in history:
+            job_id = job["id"]
+            if job_id in running_processes:
+                process = running_processes[job_id]
+                try:
+                    process.terminate()
+                except ProcessLookupError:
+                    pass
+                # We do NOT delete from running_processes here so the worker task handles it
+
+        # Clear history file
+        with open(HISTORY_FILE, "w") as f:
+            json.dump([], f, indent=2)
+
+    # Allow the background tasks (which wait for process.wait()) some time to finish their logic and update history
+    # Wait for running jobs to finish gracefully so they don't rewrite to our empty history
+    # Or simply let them rewrite and then clear it again?
+    # Better: Give them 1 second to write, then clear again.
+
+    # Run the file deletions in background
+    background_tasks.add_task(_delete_all_files_background, history)
+
+    # Return immediately, the worker tasks will rewrite to history file because they see the job completed
+    # BUT we want history to be empty.
+    # To fix this race condition, we can just clear the history file again after a small delay in a background task
+    async def _clear_history_again():
+        await asyncio.sleep(2)
+        async with history_lock:
+            with open(HISTORY_FILE, "w") as f:
+                json.dump([], f, indent=2)
+
+    background_tasks.add_task(_clear_history_again)
+
+    return {"status": "success", "deleted": len(history)}
+
 @app.delete("/api/jobs/{job_id}")
 async def cancel_job(job_id: str):
     history = []

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -233,6 +233,7 @@ export function renderApp(root) {
             <button type="button" id="cancel-all-queued-btn" class="clear-history-btn" style="border-color: rgba(249, 115, 22, 0.5); color: #f97316;">Cancel all queued</button>
             <button type="button" id="clear-queued-btn" class="clear-history-btn" style="border-color: rgba(249, 115, 22, 0.5); color: #f97316;">Clear queued</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
+            <button type="button" id="delete-all-jobs-btn" class="clear-history-btn" style="border-color: rgba(239, 68, 68, 0.5); color: #ef4444;">Delete all jobs</button>
             <a href="/api/history/export" id="export-history-btn" class="clear-history-btn" download style="text-decoration: none; border-color: rgba(139, 92, 246, 0.5); color: #8b5cf6;">Export JSON</a>
           </div>
         </div>
@@ -1022,6 +1023,30 @@ export function renderApp(root) {
       } finally {
         clearHistoryBtn.disabled = false;
         clearHistoryBtn.textContent = "Clear history";
+      }
+    });
+  }
+
+  const deleteAllJobsBtn = root.querySelector("#delete-all-jobs-btn");
+  if (deleteAllJobsBtn) {
+    deleteAllJobsBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to delete all jobs, including running ones? This cannot be undone.")) {
+        return;
+      }
+      deleteAllJobsBtn.disabled = true;
+      deleteAllJobsBtn.textContent = "Deleting...";
+      try {
+        const response = await fetch("/api/jobs", { method: "DELETE" });
+        if (response.ok) {
+          fetchJobs();
+        } else {
+          console.error("Failed to delete all jobs");
+        }
+      } catch (err) {
+        console.error("Error deleting all jobs:", err);
+      } finally {
+        deleteAllJobsBtn.disabled = false;
+        deleteAllJobsBtn.textContent = "Delete all jobs";
       }
     });
   }

--- a/website/tests/delete-all-jobs.spec.js
+++ b/website/tests/delete-all-jobs.spec.js
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Delete All Jobs', () => {
+  test('should confirm and successfully delete all jobs', async ({ page }) => {
+    // Intercept initial jobs fetch
+    await page.route('**/api/jobs*', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'job-1',
+              url: 'https://open.spotify.com/track/1',
+              status: 'Completed',
+              created_at: new Date().toISOString(),
+            },
+            {
+              id: 'job-2',
+              url: 'https://open.spotify.com/track/2',
+              status: 'Running',
+              created_at: new Date().toISOString(),
+            }
+          ])
+        });
+      } else if (route.request().method() === 'DELETE') {
+        // Mock the DELETE /api/jobs endpoint
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', deleted: 2 })
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Mock stats
+    await page.route('**/api/stats', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total_jobs: 2, successful_jobs: 1, failed_jobs: 0, total_files_downloaded: 1 })
+      });
+    });
+
+    await page.goto('/');
+
+    // Wait for the button to appear
+    const deleteAllJobsBtn = page.locator('#delete-all-jobs-btn');
+    await expect(deleteAllJobsBtn).toBeVisible();
+
+    // Verify initial jobs are rendered
+    await expect(page.locator('.job-card')).toHaveCount(2);
+
+    // Prepare to handle the dialog
+    page.on('dialog', async dialog => {
+      expect(dialog.message()).toBe('Are you sure you want to delete all jobs, including running ones? This cannot be undone.');
+      await dialog.accept();
+    });
+
+    // Setup network listener to catch the re-fetch
+    const requestPromise = page.waitForRequest(request =>
+      request.url().includes('/api/jobs') && request.method() === 'GET'
+    );
+
+    // Intercept the subsequent jobs fetch after deletion to return empty list
+    await page.unroute('**/api/jobs*');
+    await page.route('**/api/jobs*', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      } else if (route.request().method() === 'DELETE') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', deleted: 2 })
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Click the delete all jobs button
+    await deleteAllJobsBtn.click();
+
+    // Wait for the re-fetch request
+    await requestPromise;
+
+    // Verify the UI updates to show no jobs
+    await expect(page.locator('.job-card')).toHaveCount(0);
+  });
+});

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -187,7 +187,7 @@ test("can delete a job", async ({ page }) => {
 
   await page.goto("/");
 
-  const deleteBtn = page.getByRole("button", { name: "Delete" });
+  const deleteBtn = page.getByRole("button", { name: "Delete", exact: true });
   await expect(deleteBtn).toBeVisible();
 
   await deleteBtn.click();


### PR DESCRIPTION
Implement a single "Delete all jobs" button that completely clears all jobs from the system, including running and queued ones. The backend clears the `HISTORY_FILE`, terminates running job subprocesses, and safely ignores queued jobs to prevent unintended executions.

---
*PR created automatically by Jules for task [6733958968462328877](https://jules.google.com/task/6733958968462328877) started by @jjgroenendijk*