### PR TITLE
feat: Add dynamic page title for active jobs

### DIFF
--- a/docs/backlog/closed/dynamic-page-title.md
+++ b/docs/backlog/closed/dynamic-page-title.md
@@ -1,0 +1,3 @@
+# Dynamic Page Title
+
+When there are active (Running or Queued) jobs, it is a high-value homelab feature to show the count of active jobs in the browser tab title (e.g., `(2) SpotiFLAC`), so users can monitor progress without having the tab focused. When there are no active jobs, the title should be `SpotiFLAC`.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -413,6 +413,13 @@ export function renderApp(root) {
         return acc;
       }, { Queued: 0, Running: 0, Completed: 0, Failed: 0 });
 
+      const activeCount = statusCounts.Running + statusCounts.Queued;
+      if (activeCount > 0) {
+        document.title = `(${activeCount}) SpotiFLAC`;
+      } else {
+        document.title = "SpotiFLAC";
+      }
+
       const summaryElement = root.querySelector("#queue-status-summary");
       if (summaryElement) {
         summaryElement.textContent = `Queued: ${statusCounts.Queued} | Running: ${statusCounts.Running} | Completed: ${statusCounts.Completed} | Failed: ${statusCounts.Failed}`;

--- a/website/tests/dynamic-title.spec.js
+++ b/website/tests/dynamic-title.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Dynamic Page Title", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock unrelated endpoints
+    await page.route("**/api/stats*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 }),
+      });
+    });
+
+    await page.route("**/api/system/storage*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total: 1000, used: 500, free: 500 }),
+      });
+    });
+  });
+
+  test("shows active job count in title when jobs are running or queued", async ({ page }) => {
+    await page.route("**/api/jobs*", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            { id: "1", status: "Running", url: "https://open.spotify.com/track/1" },
+            { id: "2", status: "Queued", url: "https://open.spotify.com/track/2" },
+            { id: "3", status: "Completed", url: "https://open.spotify.com/track/3" }
+          ]),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await page.goto("/");
+    await expect(page).toHaveTitle("(2) SpotiFLAC");
+  });
+
+  test("shows default title when no jobs are active", async ({ page }) => {
+    await page.route("**/api/jobs*", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            { id: "3", status: "Completed", url: "https://open.spotify.com/track/3" },
+            { id: "4", status: "Failed", url: "https://open.spotify.com/track/4" }
+          ]),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await page.goto("/");
+    await expect(page).toHaveTitle("SpotiFLAC");
+  });
+
+  test("updates title dynamically when job statuses change", async ({ page }) => {
+    let callCount = 0;
+    await page.route("**/api/jobs*", async (route) => {
+      if (route.request().method() === "GET") {
+        callCount++;
+        if (callCount === 1) {
+          // Initial state: 1 running job
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { id: "1", status: "Running", url: "https://open.spotify.com/track/1" }
+            ]),
+          });
+        } else {
+          // Second state: 0 active jobs
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              { id: "1", status: "Completed", url: "https://open.spotify.com/track/1" }
+            ]),
+          });
+        }
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await page.goto("/");
+    await expect(page).toHaveTitle("(1) SpotiFLAC");
+
+    // Click refresh to trigger a second fetch and update
+    const refreshBtn = page.getByRole("button", { name: "Refresh jobs" });
+    await expect(refreshBtn).toBeVisible();
+    await refreshBtn.click();
+
+    await expect(page).toHaveTitle("SpotiFLAC");
+  });
+});


### PR DESCRIPTION
Implements the dynamic page title requirement. I invented this requirement based on the workflow guidelines, since both the troubleshooting and open backlog queues were empty. The implementation accurately counts active jobs dynamically from the `/api/jobs` endpoint and sets `document.title` so users can monitor progress in the background. Playwright tests are included, and the entire verification suite (ruff, pytest, vitest, playwright) passes.

---
*PR created automatically by Jules for task [2316081630682728022](https://jules.google.com/task/2316081630682728022) started by @jjgroenendijk*