### PR TITLE
feat: Add Cancel all running feature

### DIFF
--- a/docs/backlog/closed/01-add-cancel-all-running.md
+++ b/docs/backlog/closed/01-add-cancel-all-running.md
@@ -1,0 +1,13 @@
+# Backlog Item: Add "Cancel all running" feature
+
+## Overview
+Currently, the UI has buttons to clear jobs of different statuses and a button to "Cancel all queued". However, there is no button to "Cancel all running". This would be useful if a user wants to stop all actively executing jobs without clearing them from the history.
+
+## Implementation Details
+1. Backend (`server.py`):
+   - Add a new endpoint `POST /api/jobs/cancel-running` that iterates through history, finds all "Running" jobs, sets their status to "Cancelled", and terminates their processes.
+2. Frontend (`website/src/app.js`):
+   - Add a `<button type="button" id="cancel-all-running-btn" class="clear-history-btn btn-running">Cancel all running</button>` to the UI controls.
+   - Add an event listener to call the new API and show a confirmation prompt similar to other bulk actions.
+3. Tests (`website/tests/`):
+   - Add a Playwright test to verify the new button and its functionality.

--- a/server.py
+++ b/server.py
@@ -626,6 +626,39 @@ async def clear_failed_history():
 
     return {"status": "success", "cleared": len(cleared_jobs)}
 
+@app.post("/api/jobs/cancel-running")
+async def cancel_all_running():
+    history = []
+    cancelled_count = 0
+    cancelled_job_ids = []
+    async with history_lock:
+        if HISTORY_FILE.exists():
+            with open(HISTORY_FILE, "r") as f:
+                history = json.load(f)
+
+        new_history = []
+
+        for job in history:
+            if job.get("status") == "Running":
+                job["status"] = "Cancelled"
+                job["completed_at"] = datetime.now(timezone.utc).isoformat()
+                cancelled_count += 1
+                cancelled_job_ids.append(job["id"])
+            new_history.append(job)
+
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(new_history, f, indent=2)
+
+    for job_id in cancelled_job_ids:
+        if job_id in running_processes:
+            process = running_processes[job_id]
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+
+    return {"status": "success", "cancelled": cancelled_count}
+
 @app.post("/api/jobs/cancel-queued")
 async def cancel_all_queued():
     history = []

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -255,6 +255,7 @@ export function renderApp(root) {
             <button type="button" id="clear-running-btn" class="clear-history-btn btn-running">Clear running</button>
             <button type="button" id="retry-cancelled-btn" class="clear-history-btn btn-cancelled">Retry cancelled</button>
             <button type="button" id="clear-cancelled-btn" class="clear-history-btn btn-cancelled">Clear cancelled</button>
+            <button type="button" id="cancel-all-running-btn" class="clear-history-btn btn-running">Cancel all running</button>
             <button type="button" id="cancel-all-queued-btn" class="clear-history-btn btn-queued">Cancel all queued</button>
             <button type="button" id="clear-queued-btn" class="clear-history-btn btn-queued">Clear queued</button>
             <button type="button" id="clear-history-btn" class="clear-history-btn">Clear history</button>
@@ -1008,6 +1009,28 @@ export function renderApp(root) {
       } finally {
         cancelAllQueuedBtn.disabled = false;
         cancelAllQueuedBtn.textContent = "Cancel all queued";
+      }
+    });
+  }
+
+  const cancelAllRunningBtn = root.querySelector("#cancel-all-running-btn");
+  if (cancelAllRunningBtn) {
+    cancelAllRunningBtn.addEventListener("click", async () => {
+      if (!window.confirm("Are you sure you want to cancel all running jobs? This cannot be undone.")) {
+        return;
+      }
+      cancelAllRunningBtn.disabled = true;
+      cancelAllRunningBtn.textContent = "Cancelling...";
+      try {
+        const response = await fetch("/api/jobs/cancel-running", { method: "POST" });
+        if (response.ok) {
+          fetchJobs();
+        }
+      } catch (error) {
+        console.error("Error cancelling running jobs:", error);
+      } finally {
+        cancelAllRunningBtn.disabled = false;
+        cancelAllRunningBtn.textContent = "Cancel all running";
       }
     });
   }

--- a/website/tests/cancel-all-running.spec.js
+++ b/website/tests/cancel-all-running.spec.js
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Cancel All Running Feature', () => {
+  test('should show confirmation dialog and cancel all running jobs when accepted', async ({ page }) => {
+    let cancelCalled = false;
+
+    // Mock API routes
+    await page.route('/api/jobs', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'job-running-1',
+              url: 'https://open.spotify.com/track/running1',
+              status: 'Running',
+              files: 0,
+              created_at: new Date().toISOString(),
+              completed_at: null,
+              error_log: null
+            }
+          ])
+        });
+      }
+    });
+
+    await page.route('/api/jobs/cancel-running', async (route) => {
+      if (route.request().method() === 'POST') {
+        cancelCalled = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', cancelled: 1 })
+        });
+      }
+    });
+
+    // Handle the dialog prompt natively
+    page.on('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Are you sure you want to cancel all running jobs? This cannot be undone.');
+      await dialog.accept();
+    });
+
+    // Navigate to the app
+    await page.goto('/');
+
+    // Ensure the button exists
+    const cancelBtn = page.locator('#cancel-all-running-btn');
+    await expect(cancelBtn).toBeVisible();
+
+    // Setup request listener to wait for API call
+    const requestPromise = page.waitForRequest('/api/jobs/cancel-running');
+
+    // Click the button
+    await cancelBtn.click();
+
+    // Wait for the request
+    await requestPromise;
+
+    // Assert that the endpoint was called
+    expect(cancelCalled).toBe(true);
+  });
+
+  test('should show confirmation dialog and not cancel all running jobs when dismissed', async ({ page }) => {
+    let cancelCalled = false;
+
+    // Mock API routes
+    await page.route('/api/jobs', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'job-running-2',
+              url: 'https://open.spotify.com/track/running2',
+              status: 'Running',
+              files: 0,
+              created_at: new Date().toISOString(),
+              completed_at: null,
+              error_log: null
+            }
+          ])
+        });
+      }
+    });
+
+    await page.route('/api/jobs/cancel-running', async (route) => {
+      if (route.request().method() === 'POST') {
+        cancelCalled = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', cancelled: 1 })
+        });
+      }
+    });
+
+    // Handle the dialog prompt natively
+    page.on('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Are you sure you want to cancel all running jobs? This cannot be undone.');
+      await dialog.dismiss();
+    });
+
+    // Navigate to the app
+    await page.goto('/');
+
+    // Ensure the button exists
+    const cancelBtn = page.locator('#cancel-all-running-btn');
+    await expect(cancelBtn).toBeVisible();
+
+    // Click the button
+    await cancelBtn.click();
+
+    // Wait a brief moment to ensure request would have been sent
+    await page.waitForTimeout(500);
+
+    // Assert that the endpoint was NOT called
+    expect(cancelCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
Added a feature to cancel all currently running jobs. A backend endpoint was added to update history statuses to "Cancelled" and to terminate the running processes. A corresponding button was added to the frontend with a confirmation dialog, mapped to this endpoint. The feature is tested with Playwright E2E tests.

---
*PR created automatically by Jules for task [16181401546363331544](https://jules.google.com/task/16181401546363331544) started by @jjgroenendijk*