### PR TITLE
feat: add confirm delete job dialog

### DIFF
--- a/docs/backlog/closed/032_confirm_delete_job.md
+++ b/docs/backlog/closed/032_confirm_delete_job.md
@@ -1,0 +1,10 @@
+# Confirm Delete Job
+
+Add a confirmation dialog before deleting an individual job, similar to the cancel job confirmation.
+
+## Requirements
+- When a user clicks the "Delete" button for a job, prompt them with `window.confirm`.
+- The prompt should ask: "Are you sure you want to delete this job? This cannot be undone."
+- If the user cancels the prompt, do not delete the job.
+- If the user confirms, proceed with the deletion.
+- Write/update a Playwright test to verify this behavior.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -861,6 +861,10 @@ export function renderApp(root) {
       const jobId = event.target.dataset.jobId;
       if (!jobId) return;
 
+      if (!window.confirm("Are you sure you want to delete this job? This cannot be undone.")) {
+        return;
+      }
+
       event.target.disabled = true;
       event.target.textContent = "Deleting...";
 

--- a/website/tests/delete-job-confirm.spec.js
+++ b/website/tests/delete-job-confirm.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Delete Job Confirmation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the stats endpoint
+    await page.route('/api/stats', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          total_disk_usage_bytes: 1024 * 1024 * 500, // 500 MB
+          total_storage_capacity_bytes: 1024 * 1024 * 1024 * 10, // 10 GB
+          storage_usage_percent: 5,
+        }),
+      });
+    });
+
+    // Mock the initial jobs endpoint
+    await page.route('/api/jobs', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'job-to-delete',
+              url: 'https://open.spotify.com/track/delete-me',
+              status: 'Completed',
+              created_at: new Date().toISOString(),
+              files: 1,
+              error_log: null
+            }
+          ]),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await page.goto('/');
+  });
+
+  test('does not delete job if confirmation is cancelled', async ({ page }) => {
+    let deleteRequestMade = false;
+
+    await page.route('**/api/jobs/job-to-delete', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteRequestMade = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success' })
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    // Handle dialog: click cancel
+    page.on('dialog', dialog => dialog.dismiss());
+
+    const deleteBtn = page.getByRole('button', { name: 'Delete', exact: true });
+    await expect(deleteBtn).toBeVisible();
+
+    await deleteBtn.click();
+
+    // Verify the button text is still "Delete"
+    await expect(page.getByRole('button', { name: 'Delete', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Deleting...', exact: true })).not.toBeVisible();
+
+    expect(deleteRequestMade).toBe(false);
+  });
+
+  test('deletes job if confirmation is accepted', async ({ page }) => {
+    let deleteRequestMade = false;
+
+    await page.route('**/api/jobs/job-to-delete', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteRequestMade = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success' })
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    // Handle dialog: click accept
+    page.on('dialog', dialog => dialog.accept());
+
+    const deleteBtn = page.getByRole('button', { name: 'Delete', exact: true });
+    await expect(deleteBtn).toBeVisible();
+
+    await deleteBtn.click();
+
+    // Verify the button text changes
+    await expect(page.getByRole('button', { name: 'Deleting...', exact: true })).toBeVisible();
+
+    expect(deleteRequestMade).toBe(true);
+  });
+});

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -190,6 +190,7 @@ test("can delete a job", async ({ page }) => {
   const deleteBtn = page.getByRole("button", { name: "Delete", exact: true });
   await expect(deleteBtn).toBeVisible();
 
+  page.on('dialog', dialog => dialog.accept());
   await deleteBtn.click();
   await expect(page.getByRole("button", { name: "Deleting..." })).toBeVisible();
 


### PR DESCRIPTION
Added a confirmation dialog before deleting an individual job, similar to the cancel job confirmation.
- Modifies `website/src/app.js` to prompt `window.confirm` for `.delete-job-btn` clicks.
- Adds `website/tests/delete-job-confirm.spec.js` to thoroughly test the confirmation and cancellation flows.
- Updates existing tests in `website/tests/web-ui.spec.js` to accept the new dialog so tests continue to pass.
- Moved the backlog issue `032_confirm_delete_job.md` to `docs/backlog/closed/`.

---
*PR created automatically by Jules for task [10540011522312882158](https://jules.google.com/task/10540011522312882158) started by @jjgroenendijk*