### PR TITLE
feat(ui): add Cmd/Ctrl+Enter shortcut to submit queue form

### DIFF
--- a/docs/backlog/closed/034-cmd-enter-submit.md
+++ b/docs/backlog/closed/034-cmd-enter-submit.md
@@ -1,0 +1,6 @@
+# Support Cmd/Ctrl+Enter to queue URLs
+
+**Goal**: Allow users to queue URLs by pressing Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) while the focus is in the Spotify URLs textarea.
+
+**Details**:
+To improve user experience, we can add a keyboard shortcut to submit the queue form instead of requiring the user to click the "Queue" button. We can listen for the `keydown` event on the `#spotify-url` textarea, check if the `Enter` key is pressed along with the `metaKey` or `ctrlKey`, and if so, trigger the form submission.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -292,6 +292,13 @@ export function renderApp(root) {
         clearInputBtn.style.display = "none";
       }
     });
+
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        form.requestSubmit();
+      }
+    });
   }
 
   if (clearInputBtn) {

--- a/website/tests/cmd-enter-submit.spec.js
+++ b/website/tests/cmd-enter-submit.spec.js
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Keyboard submission', () => {
+  test('submits form on Meta+Enter (Cmd+Enter)', async ({ page }) => {
+    let jobQueued = false;
+    await page.route('**/api/jobs*', async (route, request) => {
+      if (request.method() === 'POST' && request.url().endsWith('/api/jobs')) {
+        jobQueued = true;
+        const body = JSON.parse(request.postData() || '{}');
+        expect(body.url).toBe('https://open.spotify.com/track/123');
+        await route.fulfill({
+          status: 201,
+          json: { message: "Job queued successfully", job_id: "test-job" }
+        });
+        return;
+      }
+      if (request.method() === 'GET' && request.url().endsWith('/api/jobs')) {
+        await route.fulfill({ status: 200, json: [] });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.route('**/api/stats', async route => {
+      await route.fulfill({ status: 200, json: { total_jobs: 0, total_files: 0, success_rate: 0 } });
+    });
+
+    await page.route('**/api/system/storage', async route => {
+      await route.fulfill({ status: 200, json: { total: 100, used: 10, free: 90, percentage: 10 } });
+    });
+
+    await page.goto('/');
+
+    const textarea = page.locator('#spotify-url');
+    await textarea.fill('https://open.spotify.com/track/123');
+
+    // Press Meta+Enter
+    await textarea.press('Meta+Enter');
+
+    // Wait a short moment to ensure request is intercepted
+    await page.waitForTimeout(500);
+
+    expect(jobQueued).toBe(true);
+
+    const feedback = page.locator('#queue-feedback');
+    await expect(feedback).toHaveText('Successfully queued 1 job.');
+    await expect(feedback).toHaveAttribute('data-state', 'success');
+  });
+
+  test('submits form on Control+Enter (Ctrl+Enter)', async ({ page }) => {
+    let jobQueued = false;
+    await page.route('**/api/jobs*', async (route, request) => {
+      if (request.method() === 'POST' && request.url().endsWith('/api/jobs')) {
+        jobQueued = true;
+        const body = JSON.parse(request.postData() || '{}');
+        expect(body.url).toBe('https://open.spotify.com/album/456');
+        await route.fulfill({
+          status: 201,
+          json: { message: "Job queued successfully", job_id: "test-job-2" }
+        });
+        return;
+      }
+      if (request.method() === 'GET' && request.url().endsWith('/api/jobs')) {
+        await route.fulfill({ status: 200, json: [] });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.route('**/api/stats', async route => {
+      await route.fulfill({ status: 200, json: { total_jobs: 0, total_files: 0, success_rate: 0 } });
+    });
+
+    await page.route('**/api/system/storage', async route => {
+      await route.fulfill({ status: 200, json: { total: 100, used: 10, free: 90, percentage: 10 } });
+    });
+
+    await page.goto('/');
+
+    const textarea = page.locator('#spotify-url');
+    await textarea.fill('https://open.spotify.com/album/456');
+
+    // Press Control+Enter
+    await textarea.press('Control+Enter');
+
+    // Wait a short moment to ensure request is intercepted
+    await page.waitForTimeout(500);
+
+    expect(jobQueued).toBe(true);
+
+    const feedback = page.locator('#queue-feedback');
+    await expect(feedback).toHaveText('Successfully queued 1 job.');
+    await expect(feedback).toHaveAttribute('data-state', 'success');
+  });
+});


### PR DESCRIPTION
Add support for Cmd/Ctrl+Enter shortcut to submit the queue form instead of manually clicking the button.

---
*PR created automatically by Jules for task [6183994616838033383](https://jules.google.com/task/6183994616838033383) started by @jjgroenendijk*