### PR TITLE
feat: add Ctrl+Enter shortcut to queue form

### DIFF
--- a/docs/backlog/closed/034-ctrl-enter-shortcut.md
+++ b/docs/backlog/closed/034-ctrl-enter-shortcut.md
@@ -1,0 +1,9 @@
+# Add Keyboard Shortcut to Queue URLs (Ctrl+Enter)
+
+## Problem
+Currently, users must manually click the "Queue" button to submit the form after pasting or typing Spotify URLs into the multiline textarea. Adding a keyboard shortcut would speed up the workflow.
+
+## Requirements
+- Support `Ctrl + Enter` (and `Cmd + Enter` on macOS) within the `textarea` to submit the queue form.
+- Use `form.requestSubmit()` to properly trigger the submit event and native HTML validations.
+- Include a Playwright test to verify this shortcut behavior.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -292,6 +292,13 @@ export function renderApp(root) {
         clearInputBtn.style.display = "none";
       }
     });
+
+  input.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      form.requestSubmit();
+    }
+  });
   }
 
   if (clearInputBtn) {

--- a/website/tests/ctrl-enter-shortcut.spec.js
+++ b/website/tests/ctrl-enter-shortcut.spec.js
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+test('Queue form can be submitted with Ctrl+Enter or Meta+Enter', async ({ page }) => {
+  // Mock API for /api/stats and /api/jobs to prevent background polling from interfering
+  await page.route('**/api/stats', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 }),
+  }));
+
+  await page.route('**/api/jobs', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([]),
+  }));
+
+  await page.goto('/');
+
+  const trackUrl = 'https://open.spotify.com/track/1234567890';
+  const textarea = page.locator('#spotify-url');
+
+  await textarea.fill(trackUrl);
+
+  // Intercept the POST request to create a job
+  let createJobCalled = false;
+  await page.route('**/api/jobs', async route => {
+    if (route.request().method() === 'POST') {
+      createJobCalled = true;
+      const postData = JSON.parse(route.request().postData());
+      expect(postData.url).toBe(trackUrl);
+
+      // Respond with a mock job
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'test-job-id',
+          url: trackUrl,
+          status: 'Queued',
+          created_at: new Date().toISOString(),
+          error_log: null,
+          files: 0
+        })
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  // Mock fetching jobs again to return the new job
+  await page.route('**/api/jobs', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{
+          id: 'test-job-id',
+          url: trackUrl,
+          status: 'Queued',
+          created_at: new Date().toISOString(),
+          error_log: null,
+          files: 0
+        }])
+      });
+    } else {
+        // Fallback for POST if already handled above
+        await route.fallback();
+    }
+  });
+
+
+  // Wait for the route to be hit when we press Control+Enter
+  const requestPromise = page.waitForRequest(request =>
+    request.url().includes('/api/jobs') && request.method() === 'POST'
+  );
+
+  // Press Control+Enter inside the textarea
+  await textarea.press('Control+Enter');
+
+  await requestPromise;
+
+  // Verify the POST request was hit
+  expect(createJobCalled).toBe(true);
+
+  // Verify the textarea input was cleared
+  await expect(textarea).toHaveValue('');
+
+  // The UI should show the new job card
+  await expect(page.locator('.job-card[data-job-id="test-job-id"]')).toBeVisible();
+
+  // Take a screenshot of the successful addition
+  await page.screenshot({ path: 'ctrl-enter-shortcut-test.png', fullPage: true });
+});

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -400,7 +400,9 @@ test("can clear queued jobs", async ({ page }) => {
 
   page.once("dialog", dialog => dialog.accept());
 
-  const requestPromise = page.waitForRequest("/api/history/clear-queued");
+  const requestPromise = page.waitForRequest(request =>
+    request.url().includes("/api/history/clear-queued") && request.method() === "DELETE"
+  );
   await clearQueuedBtn.click();
   await requestPromise;
 


### PR DESCRIPTION
This implements the Ctrl+Enter shortcut for the queue form. It adds the event listener, triggers native form submission via `requestSubmit()`, and includes a new Playwright test. The backlog item has been moved to closed.

---
*PR created automatically by Jules for task [5611773424049348752](https://jules.google.com/task/5611773424049348752) started by @jjgroenendijk*