### PR TITLE
feat: add backend connection status indicator

### DIFF
--- a/docs/backlog/closed/035_backend_connection_status.md
+++ b/docs/backlog/closed/035_backend_connection_status.md
@@ -1,0 +1,11 @@
+# Add Backend Connection Status Indicator
+
+As a user self-hosting SpotiFLAC, I want to know if the backend server is reachable from the web UI so I can quickly diagnose connectivity issues.
+
+## Requirements
+- Add a small visual indicator (like a colored dot or badge) to the top bar (e.g., next to the theme toggle or runtime badge).
+- The indicator should be green and say "Online" or just be green when the backend is reachable.
+- It should be red and say "Offline" (or just red) when the backend is unreachable.
+- Use the existing `/api/health` endpoint or hook into the existing periodic job polling (`fetchJobs`) to update the status.
+- Ensure the UI looks clean and matches the "Liquid Glass" style guide.
+- Add Playwright tests to verify the indicator works properly.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -159,6 +159,10 @@ export function renderApp(root) {
           <h1>SpotiFLAC</h1>
         </div>
         <div class="topbar-actions">
+          <div id="connection-status" class="connection-status status-online" aria-label="Backend connection status">
+            <span class="status-dot"></span>
+            <span class="status-text">Online</span>
+          </div>
           <button type="button" id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle dark mode">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-moon theme-icon-dark"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sun theme-icon-light"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
@@ -362,6 +366,27 @@ export function renderApp(root) {
     }
   }
 
+  async function checkConnectionStatus() {
+    const statusContainer = root.querySelector("#connection-status");
+    const statusText = root.querySelector(".status-text");
+    if (!statusContainer || !statusText) return;
+
+    try {
+      const response = await fetch("/api/health");
+      if (response.ok) {
+        statusContainer.classList.remove("status-offline");
+        statusContainer.classList.add("status-online");
+        statusText.textContent = "Online";
+      } else {
+        throw new Error("Backend not ok");
+      }
+    } catch (err) {
+      statusContainer.classList.remove("status-online");
+      statusContainer.classList.add("status-offline");
+      statusText.textContent = "Offline";
+    }
+  }
+
   async function updateStorageUsage() {
     try {
       const response = await fetch("/api/system/storage");
@@ -551,6 +576,8 @@ export function renderApp(root) {
   updateStorageUsage();
   updateJobStats();
   applyAutoRefreshState();
+  checkConnectionStatus();
+  setInterval(checkConnectionStatus, 10000); // Update connection status every 10 seconds
 
   const themeToggleBtn = root.querySelector("#theme-toggle");
 

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -215,6 +215,41 @@ h2 {
   transform: rotate(0deg) scale(1);
 }
 
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--badge-bg);
+  backdrop-filter: blur(10px) saturate(180%);
+  -webkit-backdrop-filter: blur(10px) saturate(180%);
+  border: 1px solid var(--badge-border);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--badge-text);
+  margin-right: 8px;
+  transition: all 0.3s ease;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #9ca3af;
+  box-shadow: 0 0 8px rgba(156, 163, 175, 0.5);
+}
+
+.status-online .status-dot {
+  background-color: #10b981;
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.5);
+}
+
+.status-offline .status-dot {
+  background-color: #ef4444;
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.5);
+}
+
 .runtime-badge {
   /* Glassmorphism Badge */
   background: var(--badge-bg);

--- a/website/tests/status.spec.js
+++ b/website/tests/status.spec.js
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Connection Status Indicator", () => {
+  test("shows online status when health endpoint is successful", async ({ page }) => {
+    // Mock health check and background endpoints
+    await page.route("**/api/health", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "ok" }),
+      });
+    });
+    await page.route("**/api/jobs", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+    await page.route("**/api/system/storage", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total: 100, used: 10, free: 90 }),
+      });
+    });
+    await page.route("**/api/stats", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 }),
+      });
+    });
+
+    await page.goto("/");
+
+    const statusContainer = page.locator("#connection-status");
+    await expect(statusContainer).toBeVisible();
+    await expect(statusContainer).toHaveClass(/status-online/);
+    await expect(statusContainer.locator(".status-text")).toHaveText("Online");
+  });
+
+  test("shows offline status when health endpoint fails", async ({ page }) => {
+    // Mock health check to fail
+    await page.route("**/api/health", (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Internal Server Error" }),
+      });
+    });
+    // Mock other endpoints
+    await page.route("**/api/jobs", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+    await page.route("**/api/system/storage", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total: 100, used: 10, free: 90 }),
+      });
+    });
+    await page.route("**/api/stats", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 }),
+      });
+    });
+
+    await page.goto("/");
+
+    const statusContainer = page.locator("#connection-status");
+    await expect(statusContainer).toBeVisible();
+    await expect(statusContainer).toHaveClass(/status-offline/);
+    await expect(statusContainer.locator(".status-text")).toHaveText("Offline");
+  });
+});


### PR DESCRIPTION
Adds a visual indicator in the topbar to show the backend connection status. Polls the /api/health endpoint every 10 seconds to toggle between Online (green) and Offline (red). Includes Playwright tests to verify the UI states.

---
*PR created automatically by Jules for task [9704142194010835440](https://jules.google.com/task/9704142194010835440) started by @jjgroenendijk*