### PR TITLE
feat: Show total file size for completed jobs

### DIFF
--- a/docs/backlog/closed/show-file-size.md
+++ b/docs/backlog/closed/show-file-size.md
@@ -1,0 +1,3 @@
+# Show File Size
+
+Update the UI to show the total file size for completed jobs. This gives users an idea of how much space a downloaded track or album is taking.

--- a/server.py
+++ b/server.py
@@ -80,7 +80,7 @@ async def write_history(history: List[Dict]):
         logger.error(f"Error writing history: {e}")
 
 
-async def update_job_status(job_id: str, status: str, error_log: Optional[str] = None, files: Optional[int] = None):
+async def update_job_status(job_id: str, status: str, error_log: Optional[str] = None, files: Optional[int] = None, total_size: Optional[int] = None):
     history = await read_history()
     for job in history:
         if job["id"] == job_id:
@@ -89,6 +89,8 @@ async def update_job_status(job_id: str, status: str, error_log: Optional[str] =
                 job["error_log"] = error_log
             if files is not None:
                 job["files"] = files
+            if total_size is not None:
+                job["total_size"] = total_size
             if status in ("Completed", "Failed", "Cancelled"):
                 job["completed_at"] = datetime.now(timezone.utc).isoformat()
             break
@@ -132,7 +134,8 @@ async def run_spotiflac(job_id: str, url: str):
             if process.returncode == 0:
                 # Count files
                 file_count = sum(1 for _ in job_output_dir.rglob("*") if _.is_file())
-                await update_job_status(job_id, "Completed", files=file_count)
+                total_size = sum(_.stat().st_size for _ in job_output_dir.rglob("*") if _.is_file())
+                await update_job_status(job_id, "Completed", files=file_count, total_size=total_size)
             elif process.returncode == -15: # Terminated
                 logger.info(f"Job {job_id} was terminated.")
                 # Status already updated by DELETE endpoint
@@ -163,7 +166,8 @@ async def create_job(request: JobRequest, background_tasks: BackgroundTasks):
         "status": "Queued",
         "created_at": datetime.now(timezone.utc).isoformat(),
         "error_log": None,
-        "files": 0
+        "files": 0,
+        "total_size": 0
     }
 
     history = await read_history()

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -59,7 +59,10 @@ function escapeHtml(unsafe) {
 
 function renderJob(job) {
   const errorHtml = job.error_log ? `<pre class="job-error">${escapeHtml(job.error_log)}</pre>` : "";
-  const filesText = job.files === 1 ? "1 file" : `${job.files} files`;
+  let filesText = job.files === 1 ? "1 file" : `${job.files} files`;
+  if (job.total_size) {
+    filesText += ` (${formatFileSize(job.total_size)})`;
+  }
   const canCancel = job.status === "Queued" || job.status === "Running";
   const canRetry = job.status === "Failed" || job.status === "Cancelled";
   const canDelete = job.status === "Completed" || job.status === "Failed" || job.status === "Cancelled";

--- a/website/tests/show-file-size.spec.js
+++ b/website/tests/show-file-size.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test('job card displays total size of files for completed jobs', async ({ page }) => {
+  // Mock the history API response with a job containing total_size
+  await page.route('**/api/jobs', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        json: [
+          {
+            id: 'test-job-with-size',
+            url: 'https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT',
+            status: 'Completed',
+            created_at: new Date().toISOString(),
+            files: 2,
+            total_size: 5242880, // 5 MB
+            error_log: null
+          }
+        ]
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  // Mock stats to prevent background polling from interfering
+  await page.route('**/api/stats', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: { total_jobs: 1, total_files: 2, success_rate: 100 } });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.goto('/');
+
+  // Wait for the job card to appear
+  const jobCard = page.locator('.job-card[data-job-id="test-job-with-size"]');
+  await jobCard.waitFor({ state: 'visible' });
+
+  // The meta section contains the status and the files text
+  // filesText logic: 2 files -> "2 files (5 MB)"
+  // Format is "2 files (5 MB)"
+  const metaSection = jobCard.locator('.job-meta');
+
+  // Find the span containing the files text
+  await expect(metaSection).toContainText('2 files (5 MB)');
+});


### PR DESCRIPTION
Implemented functionality to compute and display the total file size of downloaded files per job in the web UI. Ensures clear storage transparency for the user right from the dashboard.

---
*PR created automatically by Jules for task [7545121635476960567](https://jules.google.com/task/7545121635476960567) started by @jjgroenendijk*