### PR TITLE
feat: autofocus spotify url input on load

### DIFF
--- a/docs/backlog/closed/036_autofocus_spotify_url_input.md
+++ b/docs/backlog/closed/036_autofocus_spotify_url_input.md
@@ -1,0 +1,8 @@
+# Backlog Item: Autofocus Spotify URL input field
+
+## Description
+When the user opens the SpotiFLAC web UI, the Spotify URL input field should be automatically focused so they can immediately paste a URL and hit Enter without having to click the input field first.
+
+## Requirements
+- Add the `autofocus` attribute to the textarea with id `spotify-url` in `website/src/app.js`.
+- Add a Playwright test to verify that the element is focused upon page load.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -183,6 +183,7 @@ export function renderApp(root) {
               name="spotify-url"
               placeholder="https://open.spotify.com/artist/..."
               autocomplete="off"
+              autofocus
               required
               rows="3"
             ></textarea>

--- a/website/tests/autofocus-input.spec.js
+++ b/website/tests/autofocus-input.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Autofocus input', () => {
+  test('spotify url input is focused on load', async ({ page }) => {
+    // Mock API requests
+    await page.route('**/api/jobs*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([])
+      });
+    });
+
+    await page.route('**/api/system/storage', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ free: 500000000, total: 1000000000 })
+      });
+    });
+
+    await page.goto('/');
+
+    const spotifyUrlInput = page.locator('#spotify-url');
+    await expect(spotifyUrlInput).toBeFocused();
+  });
+});


### PR DESCRIPTION
- Added `autofocus` attribute to `#spotify-url` textarea in `website/src/app.js`
- Added Playwright test `website/tests/autofocus-input.spec.js`
- Moved backlog item `036_autofocus_spotify_url_input.md` from open to closed

---
*PR created automatically by Jules for task [10622680679457695880](https://jules.google.com/task/10622680679457695880) started by @jjgroenendijk*