### PR TITLE
feat: add dynamic document title for active jobs

### DIFF
--- a/docs/backlog/closed/2024-06-14_dynamic-document-title.md
+++ b/docs/backlog/closed/2024-06-14_dynamic-document-title.md
@@ -1,0 +1,12 @@
+# Dynamic Document Title for Active Jobs
+
+## Requirement
+Update the document title in the SpotiFLAC web UI to reflect the number of active jobs (Running or Queued).
+If there are 3 active jobs, the title should be `(3) SpotiFLAC`. If there are 0 active jobs, the title should be `SpotiFLAC`.
+
+This is a high-value requirement for users who leave the web UI open in a background tab, allowing them to monitor ongoing downloads without switching tabs.
+
+## Tasks
+1. In `website/src/app.js`, within the `fetchJobs` function (or a separate update function called by it), calculate the number of active jobs (`job.status === "Running" || job.status === "Queued"`).
+2. Update `document.title` accordingly.
+3. Write a Playwright test in `website/tests/document-title.spec.js` to verify this behavior.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -442,6 +442,13 @@ export function renderApp(root) {
       if (!response.ok) throw new Error("Failed to fetch");
       const jobs = await response.json();
 
+      const activeJobsCount = jobs.filter(job => job.status === "Running" || job.status === "Queued").length;
+      if (activeJobsCount > 0) {
+        document.title = `(${activeJobsCount}) SpotiFLAC`;
+      } else {
+        document.title = "SpotiFLAC";
+      }
+
       const downloadAllBtn = root.querySelector("#download-all-btn");
       if (downloadAllBtn) {
         const hasCompleted = jobs.some(job => job.status === "Completed");

--- a/website/tests/document-title.spec.js
+++ b/website/tests/document-title.spec.js
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dynamic Document Title', () => {
+  test('should show "(N) SpotiFLAC" when there are active jobs', async ({ page }) => {
+    // Intercept the /api/jobs request to return 2 active jobs
+    await page.route('/api/jobs', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-1',
+            url: 'https://open.spotify.com/track/1',
+            status: 'Running',
+            created_at: new Date().toISOString()
+          },
+          {
+            id: 'job-2',
+            url: 'https://open.spotify.com/track/2',
+            status: 'Queued',
+            created_at: new Date().toISOString()
+          },
+          {
+            id: 'job-3',
+            url: 'https://open.spotify.com/track/3',
+            status: 'Completed',
+            created_at: new Date().toISOString()
+          }
+        ])
+      });
+    });
+
+    await page.goto('/');
+
+    // Wait for the jobs to load and title to update
+    await expect(page).toHaveTitle('(2) SpotiFLAC');
+  });
+
+  test('should show "SpotiFLAC" when there are no active jobs', async ({ page }) => {
+    // Intercept the /api/jobs request to return 0 active jobs
+    await page.route('/api/jobs', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'job-1',
+            url: 'https://open.spotify.com/track/1',
+            status: 'Completed',
+            created_at: new Date().toISOString()
+          },
+          {
+            id: 'job-2',
+            url: 'https://open.spotify.com/track/2',
+            status: 'Failed',
+            created_at: new Date().toISOString()
+          }
+        ])
+      });
+    });
+
+    await page.goto('/');
+
+    // Wait for the jobs to load and title to update
+    await expect(page).toHaveTitle('SpotiFLAC');
+  });
+});


### PR DESCRIPTION
Implemented a feature to update the document title based on the number of active jobs (jobs in "Running" or "Queued" state). This helps users keep track of background processes. If there are active jobs, the title shows `(N) SpotiFLAC`, else it defaults back to `SpotiFLAC`. 

Includes:
- Logic update in `app.js` inside the `fetchJobs` function.
- A Playwright test `document-title.spec.js` to verify behavior with mocked API responses.
- Moved the generated backlog task to `docs/backlog/closed`.

---
*PR created automatically by Jules for task [10430045728100182753](https://jules.google.com/task/10430045728100182753) started by @jjgroenendijk*