### PR TITLE
feat: auto-refresh job execution logs

### DIFF
--- a/docs/backlog/closed/038_show_cover_art_already_done.md
+++ b/docs/backlog/closed/038_show_cover_art_already_done.md
@@ -1,0 +1,5 @@
+# Backlog Item: Display Cover Art in Job Cards
+
+This backlog item was already done. The code has `<img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.style.display='none'" alt="Cover art" />`.
+
+I will clean it up and start a new backlog item.

--- a/docs/backlog/closed/039_auto_refresh_job_logs.md
+++ b/docs/backlog/closed/039_auto_refresh_job_logs.md
@@ -1,0 +1,12 @@
+# Backlog Item: Auto-refresh Job Logs
+
+## Goal
+Automatically refresh the job logs when viewing them in the UI, especially when the job is "Running".
+
+## Background
+Currently, the user has to click "Refresh Logs" manually to see new log output while a job is running. Adding an auto-refresh toggle or behavior would improve the UX for tracking progress.
+
+## Acceptance Criteria
+- When a user views the logs of a "Running" job, the logs should automatically refresh periodically (e.g., every 3 seconds).
+- There should be a visual indicator or toggle to show that logs are auto-refreshing.
+- Add an automated test for this behavior.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -116,7 +116,10 @@ function renderJob(job) {
       <div class="job-logs-container" id="logs-container-${escapeHtml(job.id)}">
         <div class="job-section-header">
           <h3 class="job-section-title">Execution Logs</h3>
-          <div>
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <label style="display: flex; align-items: center; cursor: pointer; color: var(--text-color); font-size: 13px;">
+              <input type="checkbox" class="auto-refresh-logs-toggle" data-job-id="${escapeHtml(job.id)}" style="margin-right: 4px; accent-color: var(--primary-color);"> Auto-refresh
+            </label>
             <button type="button" class="copy-logs-btn job-section-btn job-section-btn-mr" data-job-id="${escapeHtml(job.id)}">Copy Logs</button>
             <button type="button" class="refresh-logs-btn job-section-btn job-section-btn-mr" data-job-id="${escapeHtml(job.id)}">Refresh Logs</button>
             <button type="button" class="close-logs-btn job-section-btn" data-job-id="${escapeHtml(job.id)}">Close</button>
@@ -658,6 +661,30 @@ export function renderApp(root) {
       const jobId = card.dataset.jobId;
       if (jobId) {
         updateProgress(jobId);
+      }
+    });
+
+    // Auto-refresh logs
+    const autoRefreshLogsToggles = root.querySelectorAll('.auto-refresh-logs-toggle:checked');
+    autoRefreshLogsToggles.forEach(async (toggle) => {
+      const jobId = toggle.dataset.jobId;
+      if (!jobId) return;
+      const logsContainer = root.querySelector(`#logs-container-${jobId}`);
+      if (logsContainer && logsContainer.style.display !== 'none') {
+        try {
+          const response = await fetch(`/api/jobs/${jobId}/log`);
+          if (response.ok) {
+            const data = await response.json();
+            const logsContent = root.querySelector(`#logs-content-${jobId}`);
+            if (logsContent) {
+              logsContent.textContent = data.log || "No logs available.";
+              // Auto-scroll to bottom
+              logsContent.scrollTop = logsContent.scrollHeight;
+            }
+          }
+        } catch (err) {
+          console.error("Failed to auto-refresh logs", err);
+        }
       }
     });
 

--- a/website/tests/auto-refresh-logs.spec.js
+++ b/website/tests/auto-refresh-logs.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Auto-refresh logs', () => {
+  test('should automatically fetch logs when toggle is checked', async ({ page }) => {
+    // Mock the job creation to have a running job
+    await page.route('**/api/jobs', async (route, request) => {
+      if (request.method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 'test-auto-refresh-job-123',
+              url: 'https://open.spotify.com/track/123',
+              status: 'Running',
+              created_at: new Date().toISOString(),
+              error_log: null,
+              files: 0,
+              total_size: 0
+            }
+          ])
+        });
+      }
+      return route.continue();
+    });
+
+    // We will respond with different logs depending on how many times it was called
+    let logFetchCount = 0;
+    await page.route('**/api/jobs/test-auto-refresh-job-123/log', async (route) => {
+      logFetchCount++;
+      const logMsg = logFetchCount === 1 ? 'Initial log content' : `Auto-refreshed log content ${logFetchCount}`;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ log: logMsg })
+      });
+    });
+
+    await page.goto('/');
+
+    const jobCard = page.locator('.job-card[data-job-id="test-auto-refresh-job-123"]');
+    await expect(jobCard).toBeVisible();
+
+    const viewLogsBtn = jobCard.locator('.view-logs-btn');
+    await viewLogsBtn.click();
+
+    const logsContainer = page.locator('#logs-container-test-auto-refresh-job-123');
+    await expect(logsContainer).toBeVisible();
+
+    const logsContent = logsContainer.locator('.job-logs-content');
+    await expect(logsContent).toContainText('Initial log content');
+
+    const autoRefreshToggle = logsContainer.locator('.auto-refresh-logs-toggle');
+    // Check the toggle
+    await autoRefreshToggle.check();
+    await expect(autoRefreshToggle).toBeChecked();
+
+    // Wait for the auto-refresh to occur (poll is every 2 seconds, wait up to 4s)
+    await expect(logsContent).toContainText('Auto-refreshed log content', { timeout: 5000 });
+  });
+});


### PR DESCRIPTION
Resolves backlog item #039 by introducing automatic refreshing for job execution logs in the UI.

Changes:
- Modified `website/src/app.js` to include the auto-refresh toggle checkbox and updated `progressPollInterval` to fetch new logs if the toggle is checked.
- Added `website/tests/auto-refresh-logs.spec.js` for E2E testing of the new functionality.
- Closed backlog item `039_auto_refresh_job_logs.md`.

---
*PR created automatically by Jules for task [2027457541528781203](https://jules.google.com/task/2027457541528781203) started by @jjgroenendijk*