### PR TITLE
feat: Add toggle button to pause/resume background polling

### DIFF
--- a/docs/backlog/closed/040_pause_resume_polling.md
+++ b/docs/backlog/closed/040_pause_resume_polling.md
@@ -1,0 +1,4 @@
+# Toggle Background Polling
+Add a pause/resume button to the global UI controls to allow users to toggle the automatic background polling of job status.
+When paused, background API requests for `/api/jobs`, `/api/stats`, etc. should stop.
+When resumed, polling should continue.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -272,6 +272,7 @@ export function renderApp(root) {
               <input type="checkbox" id="auto-refresh-toggle" class="toggle-input">
               Auto-refresh
             </label>
+            <button type="button" id="pause-polling-btn" class="clear-history-btn pause-polling-btn">Pause Polling</button>
             <label class="toggle-label">
               <input type="checkbox" id="compact-view-toggle" class="toggle-input">
               Compact view
@@ -606,15 +607,19 @@ export function renderApp(root) {
   }
 
   const autoRefreshToggle = root.querySelector("#auto-refresh-toggle");
+  const pausePollingBtn = root.querySelector("#pause-polling-btn");
+  let isPollingPaused = false;
   let pollInterval;
 
   function applyAutoRefreshState() {
     if (pollInterval) {
       clearInterval(pollInterval);
     }
-    if (autoRefreshToggle && autoRefreshToggle.checked) {
+    if (autoRefreshToggle && autoRefreshToggle.checked && !isPollingPaused) {
       pollInterval = setInterval(() => {
-        fetchJobs();
+        if (!isPollingPaused) {
+          fetchJobs();
+        }
       }, 5000);
     }
   }
@@ -626,6 +631,21 @@ export function renderApp(root) {
     autoRefreshToggle.addEventListener("change", () => {
       localStorage.setItem("autoRefresh", autoRefreshToggle.checked);
       applyAutoRefreshState();
+    });
+  }
+
+  if (pausePollingBtn) {
+    pausePollingBtn.addEventListener("click", () => {
+      isPollingPaused = !isPollingPaused;
+      if (isPollingPaused) {
+        pausePollingBtn.textContent = "Resume Polling";
+        pausePollingBtn.classList.add("paused");
+        applyAutoRefreshState(); // Clear interval
+      } else {
+        pausePollingBtn.textContent = "Pause Polling";
+        pausePollingBtn.classList.remove("paused");
+        applyAutoRefreshState(); // Restart interval
+      }
     });
   }
 
@@ -656,7 +676,11 @@ export function renderApp(root) {
   updateJobStats();
   applyAutoRefreshState();
   checkConnectionStatus();
-  setInterval(checkConnectionStatus, 10000); // Update connection status every 10 seconds
+  setInterval(() => {
+    if (!isPollingPaused) {
+      checkConnectionStatus();
+    }
+  }, 10000); // Update connection status every 10 seconds
 
   const themeToggleBtn = root.querySelector("#theme-toggle");
 
@@ -682,6 +706,8 @@ export function renderApp(root) {
 
   // Poll progress more frequently (e.g., every 2 seconds) for smoother updates
   const progressPollInterval = setInterval(() => {
+    if (isPollingPaused) return;
+
     const runningJobs = Array.from(root.querySelectorAll('.job-card')).filter(card => {
       const statusText = card.querySelector('.job-meta span:first-child')?.textContent;
       return statusText === 'Running';
@@ -718,7 +744,7 @@ export function renderApp(root) {
       }
     });
 
-    if (autoRefreshToggle && autoRefreshToggle.checked) {
+    if (autoRefreshToggle && autoRefreshToggle.checked && !isPollingPaused) {
       updateStorageUsage();
       updateJobStats();
     }

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1081,3 +1081,10 @@ button:active {
   color: var(--text-tertiary);
   margin-top: 2rem;
 }
+
+/* Pause Polling Button */
+.pause-polling-btn.paused {
+  background-color: var(--accent-color);
+  color: white;
+  border-color: var(--accent-color);
+}

--- a/website/tests/app.spec.js
+++ b/website/tests/app.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Pause/Resume Polling', () => {
+  test('should toggle pause polling button and state', async ({ page }) => {
+    // Mock API requests to avoid errors
+    await page.route('**/api/jobs*', async route => await route.fulfill({ json: [] }));
+    await page.route('**/api/health', async route => await route.fulfill({ status: 200 }));
+    await page.route('**/api/stats', async route => await route.fulfill({ json: { total_jobs: 0, total_files: 0, success_rate: "0" } }));
+
+    await page.goto('/');
+
+    const pauseBtn = page.locator('#pause-polling-btn');
+    await expect(pauseBtn).toBeVisible();
+    await expect(pauseBtn).toHaveText('Pause Polling');
+
+    await pauseBtn.click();
+    await expect(pauseBtn).toHaveText('Resume Polling');
+    await expect(pauseBtn).toHaveClass(/paused/);
+
+    await pauseBtn.click();
+    await expect(pauseBtn).toHaveText('Pause Polling');
+    await expect(pauseBtn).not.toHaveClass(/paused/);
+  });
+});

--- a/website/tests/pause_polling_interval.spec.js
+++ b/website/tests/pause_polling_interval.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Pause/Resume Polling Interval', () => {
+  test('should not poll when paused', async ({ page }) => {
+    let statsPollCount = 0;
+
+    // Mock API requests
+    await page.route('**/api/jobs*', async route => await route.fulfill({ json: [] }));
+    await page.route('**/api/health', async route => await route.fulfill({ status: 200 }));
+    await page.route('**/api/stats', async route => {
+        statsPollCount++;
+        await route.fulfill({ json: { total_jobs: 0, total_files: 0, success_rate: "0" } });
+    });
+
+    await page.goto('/');
+
+    const pauseBtn = page.locator('#pause-polling-btn');
+    await expect(pauseBtn).toBeVisible();
+
+    // Verify polling starts initially
+    await page.waitForTimeout(2500);
+    const initialCount = statsPollCount;
+    expect(initialCount).toBeGreaterThan(0);
+
+    // Pause polling
+    await pauseBtn.click();
+    await expect(pauseBtn).toHaveClass(/paused/);
+
+    // Wait and verify no more polling
+    const countAfterPause = statsPollCount;
+    await page.waitForTimeout(2500);
+    expect(statsPollCount).toBe(countAfterPause);
+  });
+});


### PR DESCRIPTION
- Implemented a "Pause Polling" button in the SpotiFLAC web UI to allow users to toggle automatic background API polling.
- When paused, background intervals for fetching jobs, updating stats, and checking connection status are suspended to prevent unnecessary network requests.
- Added corresponding styles to visually indicate the paused state.
- Added comprehensive Playwright tests to verify the UI toggle and the correct suppression of background API requests.
- Cleaned up the associated backlog item by moving it to the closed directory.

---
*PR created automatically by Jules for task [7035830130358534816](https://jules.google.com/task/7035830130358534816) started by @jjgroenendijk*