### PR TITLE
feat(ui): unify auto-refresh controls into a single button

### DIFF
--- a/docs/backlog/closed/01-auto-refresh.md
+++ b/docs/backlog/closed/01-auto-refresh.md
@@ -1,0 +1,12 @@
+# Play/Pause UI for Auto-refresh polling
+
+Currently, there are two distinct controls for polling:
+1. `auto-refresh-toggle` (a checkbox) that starts/stops an interval on change.
+2. `pause-polling-btn` (a button) that toggles `isPollingPaused` flag inside the interval.
+
+These controls should be unified into a single Play/Pause button for better user experience.
+
+1. Remove `auto-refresh-toggle` checkbox and its label.
+2. Repurpose `pause-polling-btn` to be a toggle button (Play/Pause Auto-refresh).
+3. The interval should keep running (or be cleared/recreated) based on the state. It's simpler to keep the interval running but just toggle the `isPollingPaused` flag, and update the button text to show the current state ("Pause Auto-refresh" / "Resume Auto-refresh").
+4. Update `localStorage` to save the "isPollingPaused" state instead of "autoRefresh".

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -269,11 +269,7 @@ export function renderApp(root) {
             <a href="/api/history/download" id="download-all-btn" class="clear-history-btn download-link" download>Download all completed</a>
             <a href="/api/history/logs/download" id="download-all-logs-btn" class="clear-history-btn download-link" download>Download all logs</a>
             <button type="button" id="refresh-jobs-btn" class="clear-history-btn">Refresh jobs</button>
-            <label class="toggle-label">
-              <input type="checkbox" id="auto-refresh-toggle" class="toggle-input">
-              Auto-refresh
-            </label>
-            <button type="button" id="pause-polling-btn" class="clear-history-btn pause-polling-btn">Pause Polling</button>
+            <button type="button" id="pause-polling-btn" class="clear-history-btn pause-polling-btn">Pause Auto-refresh</button>
             <label class="toggle-label">
               <input type="checkbox" id="compact-view-toggle" class="toggle-input">
               Compact view
@@ -630,45 +626,40 @@ export function renderApp(root) {
     });
   }
 
-  const autoRefreshToggle = root.querySelector("#auto-refresh-toggle");
   const pausePollingBtn = root.querySelector("#pause-polling-btn");
-  let isPollingPaused = false;
+  let isPollingPaused = localStorage.getItem("isPollingPaused") === "true";
   let pollInterval;
 
   function applyAutoRefreshState() {
     if (pollInterval) {
       clearInterval(pollInterval);
     }
-    if (autoRefreshToggle && autoRefreshToggle.checked && !isPollingPaused) {
-      pollInterval = setInterval(() => {
-        if (!isPollingPaused) {
-          fetchJobs();
-        }
-      }, 5000);
-    }
-  }
-
-  if (autoRefreshToggle) {
-    const savedAutoRefresh = localStorage.getItem("autoRefresh");
-    autoRefreshToggle.checked = savedAutoRefresh !== "false"; // Default to true
-
-    autoRefreshToggle.addEventListener("change", () => {
-      localStorage.setItem("autoRefresh", autoRefreshToggle.checked);
-      applyAutoRefreshState();
-    });
+    pollInterval = setInterval(() => {
+      if (!isPollingPaused) {
+        fetchJobs();
+      }
+    }, 5000);
   }
 
   if (pausePollingBtn) {
+    // Initial UI state
+    if (isPollingPaused) {
+      pausePollingBtn.textContent = "Resume Auto-refresh";
+      pausePollingBtn.classList.add("paused");
+    } else {
+      pausePollingBtn.textContent = "Pause Auto-refresh";
+      pausePollingBtn.classList.remove("paused");
+    }
+
     pausePollingBtn.addEventListener("click", () => {
       isPollingPaused = !isPollingPaused;
+      localStorage.setItem("isPollingPaused", isPollingPaused);
       if (isPollingPaused) {
-        pausePollingBtn.textContent = "Resume Polling";
+        pausePollingBtn.textContent = "Resume Auto-refresh";
         pausePollingBtn.classList.add("paused");
-        applyAutoRefreshState(); // Clear interval
       } else {
-        pausePollingBtn.textContent = "Pause Polling";
+        pausePollingBtn.textContent = "Pause Auto-refresh";
         pausePollingBtn.classList.remove("paused");
-        applyAutoRefreshState(); // Restart interval
       }
     });
   }
@@ -768,7 +759,7 @@ export function renderApp(root) {
       }
     });
 
-    if (autoRefreshToggle && autoRefreshToggle.checked && !isPollingPaused) {
+    if (!isPollingPaused) {
       updateStorageUsage();
       updateJobStats();
     }

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -69,7 +69,7 @@ describe("renderApp", () => {
 
   it("polls api endpoints at correct intervals when auto-refresh is enabled", async () => {
     vi.useFakeTimers();
-    const dom = new JSDOM('<!DOCTYPE html><div id="root"><input type="checkbox" id="auto-refresh-toggle" checked /></div>', {
+    const dom = new JSDOM('<!DOCTYPE html><div id="root"><button type="button" id="pause-polling-btn">Pause Auto-refresh</button></div>', {
       url: "http://localhost",
     });
     global.document = dom.window.document;

--- a/website/tests/app.spec.js
+++ b/website/tests/app.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Pause/Resume Polling', () => {
+test.describe('Pause/Resume Auto-refresh', () => {
   test('should toggle pause polling button and state', async ({ page }) => {
     // Mock API requests to avoid errors
     await page.route('**/api/jobs*', async route => await route.fulfill({ json: [] }));
@@ -11,14 +11,14 @@ test.describe('Pause/Resume Polling', () => {
 
     const pauseBtn = page.locator('#pause-polling-btn');
     await expect(pauseBtn).toBeVisible();
-    await expect(pauseBtn).toHaveText('Pause Polling');
+    await expect(pauseBtn).toHaveText('Pause Auto-refresh');
 
     await pauseBtn.click();
-    await expect(pauseBtn).toHaveText('Resume Polling');
+    await expect(pauseBtn).toHaveText('Resume Auto-refresh');
     await expect(pauseBtn).toHaveClass(/paused/);
 
     await pauseBtn.click();
-    await expect(pauseBtn).toHaveText('Pause Polling');
+    await expect(pauseBtn).toHaveText('Pause Auto-refresh');
     await expect(pauseBtn).not.toHaveClass(/paused/);
   });
 });

--- a/website/tests/web-ui.spec.js
+++ b/website/tests/web-ui.spec.js
@@ -306,29 +306,24 @@ test('can view job logs', async ({ page }) => {
 test("can toggle auto-refresh", async ({ page }) => {
   await page.goto("/");
 
-  const autoRefreshCheckbox = page.getByRole("checkbox", { name: "Auto-refresh" });
-  await expect(autoRefreshCheckbox).toBeVisible();
+  const pauseBtn = page.locator('#pause-polling-btn');
+  await expect(pauseBtn).toBeVisible();
+  await expect(pauseBtn).toHaveText('Pause Auto-refresh');
 
-  // Default is true based on our implementation, so unchecking it should work
-  if (await autoRefreshCheckbox.isChecked()) {
-      await autoRefreshCheckbox.uncheck();
-      await expect(autoRefreshCheckbox).not.toBeChecked();
-  } else {
-      await autoRefreshCheckbox.check();
-      await expect(autoRefreshCheckbox).toBeChecked();
-  }
+  // Click to pause
+  await pauseBtn.click();
+  await expect(pauseBtn).toHaveText('Resume Auto-refresh');
+  await expect(pauseBtn).toHaveClass(/paused/);
 
   // Reload to verify it persists
   await page.reload();
+  await expect(pauseBtn).toHaveText('Resume Auto-refresh');
+  await expect(pauseBtn).toHaveClass(/paused/);
 
-  // Because we don't mock localStorage directly in Playwright across reloads easily without extra setup,
-  // the page context usually retains localStorage if on same origin. Let's verify it stayed unchecked/checked based on last action.
-  // We can just flip it and check the immediate UI state.
-  await autoRefreshCheckbox.uncheck();
-  await expect(autoRefreshCheckbox).not.toBeChecked();
-
-  await autoRefreshCheckbox.check();
-  await expect(autoRefreshCheckbox).toBeChecked();
+  // Click to resume
+  await pauseBtn.click();
+  await expect(pauseBtn).toHaveText('Pause Auto-refresh');
+  await expect(pauseBtn).not.toHaveClass(/paused/);
 });
 
 test("can refresh job list", async ({ page }) => {
@@ -1519,11 +1514,13 @@ test('can queue an artist URL and filter by Artist type', async ({ page }) => {
   await page.fill('[name="spotify-url"]', artistUrl);
 
   // Set up request listener before clicking
-  const requestPromise = page.waitForRequest('**/api/jobs*');
+  const requestPromise = page.waitForRequest(req => req.url().includes('/api/jobs') && req.method() === 'POST');
   await page.click('button[type="submit"]');
 
   // Wait for the request to be made
   const request = await requestPromise;
+
+  await page.waitForTimeout(100);
 
   expect(request.method()).toBe('POST');
   expect(requestMade).toBe(true);


### PR DESCRIPTION
Unifies the auto-refresh checkbox and 'Pause Polling' button into a single toggle button in the SpotiFLAC web UI, persisting the state to `localStorage`. Fixes corresponding frontend unit tests and Playwright E2E tests.

---
*PR created automatically by Jules for task [12213852685961536697](https://jules.google.com/task/12213852685961536697) started by @jjgroenendijk*