### PR TITLE
fix: retain provider and quality attributes on job retry

### DIFF
--- a/website/src/app.js
+++ b/website/src/app.js
@@ -68,7 +68,7 @@ function renderJob(job) {
   const canDelete = job.status === "Completed" || job.status === "Failed" || job.status === "Cancelled";
   const cancelBtnHtml = canCancel ? `<button type="button" class="cancel-job-btn" data-job-id="${escapeHtml(job.id)}">Cancel</button>` : "";
   const retryText = job.status === "Completed" ? "Re-queue" : "Retry";
-  const retryBtnHtml = canRetry ? `<button type="button" class="retry-job-btn" data-job-url="${escapeHtml(job.url)}">${retryText}</button>` : "";
+  const retryBtnHtml = canRetry ? `<button type="button" class="retry-job-btn" data-job-url="${escapeHtml(job.url)}" data-job-service="${escapeHtml(job.service || '')}" data-job-quality="${escapeHtml(job.quality || '')}">${retryText}</button>` : "";
   const deleteBtnHtml = canDelete ? `<button type="button" class="delete-job-btn" data-job-id="${escapeHtml(job.id)}">Delete</button>` : "";
   const viewLogsBtnHtml = `<button type="button" class="view-logs-btn" data-job-id="${escapeHtml(job.id)}">View Logs</button>`;
   const viewFilesBtnHtml = job.status === "Completed" ? `<button type="button" class="view-files-btn" data-job-id="${escapeHtml(job.id)}">View Files</button>` : "";
@@ -1026,6 +1026,8 @@ export function renderApp(root) {
 
     if (event.target.classList.contains("retry-job-btn")) {
       const jobUrl = event.target.dataset.jobUrl;
+      const jobService = event.target.dataset.jobService;
+      const jobQuality = event.target.dataset.jobQuality;
       if (!jobUrl) return;
 
       const isRequeue = event.target.textContent.trim() === "Re-queue";
@@ -1036,7 +1038,7 @@ export function renderApp(root) {
         const response = await fetch("/api/jobs", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ url: jobUrl })
+          body: JSON.stringify({ url: jobUrl, service: jobService || undefined, quality: jobQuality || undefined })
         });
         if (response.ok) {
           fetchJobs();
@@ -1397,7 +1399,7 @@ export function renderApp(root) {
             fetch("/api/jobs", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ url: job.url })
+              body: JSON.stringify({ url: job.url, service: job.service, quality: job.quality })
             })
           );
 
@@ -1428,7 +1430,7 @@ export function renderApp(root) {
             fetch("/api/jobs", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ url: job.url })
+              body: JSON.stringify({ url: job.url, service: job.service, quality: job.quality })
             })
           );
 
@@ -1464,7 +1466,7 @@ export function renderApp(root) {
             return fetch("/api/jobs", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ url: job.url })
+              body: JSON.stringify({ url: job.url, service: job.service, quality: job.quality })
             });
           });
 
@@ -1495,7 +1497,7 @@ export function renderApp(root) {
             fetch("/api/jobs", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ url: job.url })
+              body: JSON.stringify({ url: job.url, service: job.service, quality: job.quality })
             })
           );
 


### PR DESCRIPTION
Fixes a bug where the newly introduced "Filter by Provider" fields (service, quality) were lost when a user clicked the retry or requeue buttons on existing jobs. All frontend retry POST requests now accurately construct payloads using the job's existing service and quality.

---
*PR created automatically by Jules for task [18324098231030301849](https://jules.google.com/task/18324098231030301849) started by @jjgroenendijk*