### PR TITLE
Add cover art download via native image linking

### DIFF
--- a/docs/backlog/closed/download-cover-art.md
+++ b/docs/backlog/closed/download-cover-art.md
@@ -1,0 +1,6 @@
+# Download Cover Art Button
+
+The web UI currently shows the cover art of the job but does not provide a direct way to download the full resolution image natively.
+
+Requirement:
+Add a download button or link directly on the track cover image in the job card that triggers a native file download of the cover art from the `/api/jobs/{id}/cover` endpoint. The implementation must not require backend `Content-Disposition: attachment` modifications, and instead rely on frontend native features like `<a>` tags with the `download` attribute as outlined in system memory.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -82,7 +82,7 @@ function renderJob(job) {
   return `
     <article class="job-card" data-job-id="${escapeHtml(job.id)}">
       <input type="checkbox" class="job-select-checkbox" data-job-id="${escapeHtml(job.id)}" aria-label="Select job" style="margin-right: 10px; margin-bottom: 10px; width: 18px; height: 18px; accent-color: var(--primary-color);">
-      <img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.style.display='none'" alt="Cover art" />
+      <a href="/api/jobs/${escapeHtml(job.id)}/cover" download="cover.jpg" class="cover-download-link"><img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.parentNode.style.display='none'" alt="Cover art" /></a>
       <div>
         <p class="job-title">
           <a href="${escapeHtml(job.url)}" target="_blank" rel="noopener noreferrer" class="source-link">${escapeHtml(job.url)}</a>


### PR DESCRIPTION
This submission implements the cover art download feature based on the requirements from `download-cover-art.md`. Users can now download job cover art by clicking on the image in the web UI.

Testing included Vitest, Playwright, Backend, and visual headless screenshot verification. No regressions identified.

---
*PR created automatically by Jules for task [7724512419857803928](https://jules.google.com/task/7724512419857803928) started by @jjgroenendijk*