### PR TITLE
feat: add export history as CSV functionality

### DIFF
--- a/docs/backlog/open/new-requirement.md
+++ b/docs/backlog/open/new-requirement.md
@@ -1,0 +1,22 @@
+# Backlog Item: Add Feature to Export History as CSV
+
+Since there are no open troubleshooting cases or backlog items, I need to invent a high-value requirement for the SpotiFLAC web UI, as per AGENTS.md rule 4.
+
+## Proposed Feature: Export History as CSV
+
+**Description:**
+Add functionality to export the job history as a CSV file. The web UI currently has an "Export JSON" button, but providing a CSV option would be highly beneficial for users who want to view their job history in spreadsheet applications like Excel or Google Sheets.
+
+**Value:**
+A CSV export allows users to easily analyze their job history, filter, sort, and create reports using standard spreadsheet software, providing a homelab-friendly way to manage large amounts of download history data.
+
+**Implementation Plan:**
+1.  **Backend (`server.py`):**
+    *   Add a new `GET` endpoint `/api/history/export/csv`.
+    *   This endpoint will read `HISTORY_FILE`, convert the JSON data to CSV format (using Python's `csv` module and `io.StringIO`), and return a `StreamingResponse` or a `Response` with `text/csv` media type and `Content-Disposition: attachment` header.
+2.  **Frontend (`website/src/app.js`):**
+    *   Add a new button "Export CSV" next to the existing "Export JSON" button in the control panel.
+    *   Set the `href` of the button to `/api/history/export/csv` and add the `download` attribute.
+3.  **Tests:**
+    *   **Backend:** Add tests for the new `/api/history/export/csv` endpoint in `tests/test_server.py`.
+    *   **Frontend:** Add a Playwright test in `website/tests/export-csv.spec.js` to ensure the button is present and points to the correct URL.

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import csv
 import json
 import logging
 import os
@@ -9,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from fastapi import FastAPI, HTTPException, BackgroundTasks, Request
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Request, Response
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, HttpUrl
@@ -468,7 +469,39 @@ async def export_history_json():
         filename="SpotiFLAC-history.json"
     )
 
+
+@app.get("/api/history/export/csv")
+async def export_history_csv():
+    if not HISTORY_FILE.exists():
+        return Response(
+            content="",
+            media_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="SpotiFLAC-history.csv"'}
+        )
+
+    try:
+        with open(HISTORY_FILE, "r") as f:
+            history = json.load(f)
+    except json.JSONDecodeError:
+        history = []
+
+    output = io.StringIO()
+    # Define standard fields based on JobResponse properties
+    fieldnames = ["id", "url", "status", "created_at", "error_log", "files", "completed_at"]
+    writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction='ignore')
+
+    writer.writeheader()
+    for job in history:
+        writer.writerow(job)
+
+    return Response(
+        content=output.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="SpotiFLAC-history.csv"'}
+    )
+
 def _delete_job_files(job_id: str):
+
     import shutil
     job_dir = DATA_DIR / job_id
     if job_dir.exists() and job_dir.is_dir():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -612,3 +612,25 @@ def test_health_endpoint():
     response = client.get("/api/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+@patch('server.run_spotiflac')
+def test_export_history_csv(mock_run):
+    # Clear history first
+    client.delete("/api/jobs")
+
+    # Create a job
+    response = client.post("/api/jobs", json={"url": "https://open.spotify.com/track/123"})
+    assert response.status_code == 200
+
+    # Get the CSV
+    csv_response = client.get("/api/history/export/csv")
+    assert csv_response.status_code == 200
+    assert csv_response.headers["Content-Type"] == "text/csv; charset=utf-8"
+    assert 'attachment; filename="SpotiFLAC-history.csv"' in csv_response.headers["Content-Disposition"]
+
+    csv_data = csv_response.text
+    # Check headers
+    assert "id,url,status,created_at,error_log,files,completed_at" in csv_data
+    # Check data row exists and contains the correct url and status
+    assert "https://open.spotify.com/track/123" in csv_data
+    assert "Queued" in csv_data

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -291,6 +291,7 @@ export function renderApp(root) {
             <button type="button" id="delete-selected-btn" class="clear-history-btn btn-danger hidden-btn" disabled>Delete selected</button>
             <button type="button" id="delete-all-jobs-btn" class="clear-history-btn btn-danger">Delete all jobs</button>
             <a href="/api/history/export" id="export-history-btn" class="clear-history-btn btn-export download-link" download>Export JSON</a>
+            <a href="/api/history/export/csv" id="export-history-csv-btn" class="clear-history-btn btn-export download-link" download>Export CSV</a>
           </div>
         </div>
         <div id="queue-status-summary" class="queue-status-summary"></div>

--- a/website/tests/export-csv.spec.js
+++ b/website/tests/export-csv.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Export CSV Link', () => {
+  test('should display Export CSV link with correct href', async ({ page }) => {
+    // Mock API requests
+    await page.route('**/api/jobs*', async route => await route.fulfill({ json: [] }));
+    await page.route('**/api/health', async route => await route.fulfill({ status: 200 }));
+    await page.route('**/api/stats', async route => await route.fulfill({ json: { total_jobs: 0, total_files: 0, success_rate: 0 } }));
+    await page.route('**/api/system/storage', async route => await route.fulfill({ json: { total: 1000, used: 500, free: 500 } }));
+    await page.route('**/api/system/info', async route => await route.fulfill({ json: { version: "1.0", platform: "linux" } }));
+
+    await page.goto('/');
+
+    const exportCsvLink = page.locator('#export-history-csv-btn');
+    await expect(exportCsvLink).toBeVisible();
+    await expect(exportCsvLink).toHaveAttribute('href', '/api/history/export/csv');
+    await expect(exportCsvLink).toHaveAttribute('download', '');
+    await expect(exportCsvLink).toHaveText('Export CSV');
+  });
+});


### PR DESCRIPTION
Added functionality to export the SpotiFLAC job history as a CSV file to improve homelab analytics capabilities. This adds a new UI button and a backing API endpoint, with full test coverage for both backend logic and frontend interactions.

---
*PR created automatically by Jules for task [2915460921209144756](https://jules.google.com/task/2915460921209144756) started by @jjgroenendijk*