### PR TITLE
Prevent FOUC for dark mode

### DIFF
--- a/docs/backlog/closed/042_dark_mode_fouc.md
+++ b/docs/backlog/closed/042_dark_mode_fouc.md
@@ -1,0 +1,9 @@
+# Prevent Dark Mode FOUC
+
+## Description
+When a user visits the SpotiFLAC web UI and they have dark mode enabled (via `localStorage` or `prefers-color-scheme`), there is a flash of unstyled content (FOUC) where the page briefly loads in light mode before the JavaScript in `app.js` runs and applies the `dark` class to the `<html>` element.
+
+## Acceptance Criteria
+- A script should be added to the `<head>` of `website/index.html` that synchronously checks `localStorage` and `matchMedia` to apply the `dark` class before the body is parsed.
+- This prevents the screen from flashing white when reloading the page in dark mode.
+- The existing logic in `app.js` that initializes the theme should be retained to keep the UI components (like the toggle button) in sync.

--- a/website/index.html
+++ b/website/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SpotiFLAC</title>
+    <script>
+      (function() {
+        const savedTheme = localStorage.getItem("theme");
+        if (savedTheme === "dark" || (!savedTheme && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
   </head>
   <body>
     <main id="app"></main>


### PR DESCRIPTION
Prevents the white flash when loading the app with dark mode enabled.

---
*PR created automatically by Jules for task [316323666261163376](https://jules.google.com/task/316323666261163376) started by @jjgroenendijk*