### PR TITLE
Add keyboard navigation for job cards in web UI

### DIFF
--- a/docs/backlog/closed/043_keyboard_navigation_jobs.md
+++ b/docs/backlog/closed/043_keyboard_navigation_jobs.md
@@ -1,0 +1,9 @@
+# Keyboard Navigation for Jobs
+
+## Description
+Currently, the user has to use Tab to go through every single button in the job list. It would be helpful to allow keyboard navigation between job cards using arrow keys.
+
+## Requirements
+- Add `tabindex="0"` to job cards so they can receive focus.
+- Allow using Up/Down arrow keys to move focus between job cards in the list.
+- Add an accessible `aria-label` to the job card to identify the job.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -80,7 +80,7 @@ function renderJob(job) {
   const completedAtHtml = job.completed_at ? `<p class="job-source job-completed-time">Completed: ${new Date(job.completed_at).toLocaleString()} (Duration: ${durationStr})</p>` : "";
 
   return `
-    <article class="job-card" data-job-id="${escapeHtml(job.id)}">
+    <article class="job-card" data-job-id="${escapeHtml(job.id)}" tabindex="0" aria-label="Job for ${escapeHtml(job.url)}">
       <input type="checkbox" class="job-select-checkbox" data-job-id="${escapeHtml(job.id)}" aria-label="Select job" style="margin-right: 10px; margin-bottom: 10px; width: 18px; height: 18px; accent-color: var(--primary-color);">
       <a href="/api/jobs/${escapeHtml(job.id)}/cover" download="cover.jpg" class="cover-download-link"><img src="/api/jobs/${escapeHtml(job.id)}/cover" class="track-cover" onerror="this.parentNode.style.display='none'" alt="Cover art" /></a>
       <div>
@@ -866,6 +866,27 @@ export function renderApp(root) {
     } finally {
       queueBtn.disabled = false;
       queueBtn.textContent = "Queue";
+    }
+  });
+
+  jobList.addEventListener("keydown", (event) => {
+    const card = event.target.closest(".job-card");
+    if (!card) return;
+
+    // Only trigger navigation if the card itself has focus
+    if (event.target !== card) return;
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const cards = Array.from(jobList.querySelectorAll(".job-card"));
+      const currentIndex = cards.indexOf(card);
+      let nextIndex;
+      if (event.key === "ArrowDown") {
+        nextIndex = currentIndex + 1 < cards.length ? currentIndex + 1 : 0;
+      } else {
+        nextIndex = currentIndex - 1 >= 0 ? currentIndex - 1 : cards.length - 1;
+      }
+      cards[nextIndex].focus();
     }
   });
 

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1088,3 +1088,8 @@ button:active {
   color: white;
   border-color: var(--accent-color);
 }
+
+.job-card:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Adds keyboard navigation to the SpotiFLAC web UI job cards so that users can traverse the job list using up and down arrow keys. Job cards are now focusable using the `tabindex` attribute, and focus navigation logic was added to intercept arrow keys when a job card holds focus.

---
*PR created automatically by Jules for task [17701900167510657103](https://jules.google.com/task/17701900167510657103) started by @jjgroenendijk*