### PR TITLE
feat: Expand Spotify validation to include shows and episodes

### DIFF
--- a/docs/backlog/closed/new-requirement.md
+++ b/docs/backlog/closed/new-requirement.md
@@ -1,0 +1,10 @@
+# New Requirement: Expand Spotify Validation to Include Shows and Episodes
+
+## Motivation
+Currently, SpotiFLAC's frontend URL validation only accepts `track`, `album`, `playlist`, and `artist` endpoints from `open.spotify.com`. Spotify also hosts podcasts (shows and episodes) that users might want to process. By relaxing the validation to include `show` and `episode`, we open up the UI to a broader range of Spotify content, making the tool more versatile for users who want to manage a wider array of audio files.
+
+## Acceptance Criteria
+- [x] The `isSpotifyUrl` function in `website/src/app.js` is updated to include `show` and `episode` in its list of valid URL parts.
+- [x] Tests in `website/src/app.test.js` are updated to cover `show` and `episode` URL validation cases.
+- [x] All tests pass.
+- [x] The change is committed and this backlog item is moved to `docs/backlog/closed/`.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -6,7 +6,7 @@ export function isSpotifyUrl(value) {
 
     return (
       host === "open.spotify.com" &&
-      ["track", "album", "playlist", "artist"].includes(parts[0]) &&
+      ["track", "album", "playlist", "artist", "show", "episode"].includes(parts[0]) &&
       Boolean(parts[1])
     );
   } catch {

--- a/website/src/app.test.js
+++ b/website/src/app.test.js
@@ -19,6 +19,14 @@ describe("isSpotifyUrl", () => {
     expect(isSpotifyUrl("https://open.spotify.com/album/1ATL5GLyefJaxhQzSPVrLX")).toBe(true);
   });
 
+  it("accepts valid show URLs", () => {
+    expect(isSpotifyUrl("https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk")).toBe(true);
+  });
+
+  it("accepts valid episode URLs", () => {
+    expect(isSpotifyUrl("https://open.spotify.com/episode/7G5O2wWmbpExz8wKqR24wR")).toBe(true);
+  });
+
   it("rejects invalid hosts", () => {
     expect(isSpotifyUrl("https://soundcloud.com/track/123")).toBe(false);
   });
@@ -31,6 +39,14 @@ describe("classifySpotifyUrl", () => {
 
   it("classifies albums", () => {
     expect(classifySpotifyUrl("https://open.spotify.com/album/123")).toBe("album");
+  });
+
+  it("classifies shows", () => {
+    expect(classifySpotifyUrl("https://open.spotify.com/show/123")).toBe("show");
+  });
+
+  it("classifies episodes", () => {
+    expect(classifySpotifyUrl("https://open.spotify.com/episode/123")).toBe("episode");
   });
 });
 


### PR DESCRIPTION
Resolves requirement to expand Spotify URL validation to include podcasts (shows and episodes).

---
*PR created automatically by Jules for task [7783944647116532603](https://jules.google.com/task/7783944647116532603) started by @jjgroenendijk*