### PR TITLE
feat: Add timeout to frontend health polling

### DIFF
--- a/docs/backlog/open/044_add_health_timeout.md
+++ b/docs/backlog/open/044_add_health_timeout.md
@@ -1,0 +1,5 @@
+# Add Health Check Timeout
+
+The UI currently polls `/api/health` to determine connection status. However, if the backend hangs indefinitely, the UI fetch request will wait for the browser's default timeout (which can be very long), causing the UI to falsely appear online.
+
+We should implement a timeout (e.g. 5 seconds) for the health check fetch request in the UI so that a hung backend is quickly reported as offline.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -456,8 +456,12 @@ export function renderApp(root) {
     const statusText = root.querySelector(".status-text");
     if (!statusContainer || !statusText) return;
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
     try {
-      const response = await fetch("/api/health");
+      const response = await fetch("/api/health", { signal: controller.signal });
+      clearTimeout(timeoutId);
       if (response.ok) {
         statusContainer.classList.remove("status-offline");
         statusContainer.classList.add("status-online");

--- a/website/tests/download_job_form.spec.js
+++ b/website/tests/download_job_form.spec.js
@@ -58,12 +58,14 @@ test('Download job form submits with URL and quality setting', async ({ page }) 
   await page.selectOption('#service-select', 'qobuz');
   await page.selectOption('#quality-select', 'LOSSLESS');
 
+  // Verify the payload includes the quality
+  // Add a small wait to ensure request is dispatched
+  const responsePromise = page.waitForResponse(response => response.url().includes('/api/jobs') && response.request().method() === 'POST');
+
   // Submit the form
   await page.click('button[type="submit"]');
 
-  // Verify the payload includes the quality
-  // Add a small wait to ensure request is dispatched
-  await page.waitForResponse(response => response.url().includes('/api/jobs') && response.request().method() === 'POST');
+  await responsePromise;
   expect(submittedPayload).not.toBeNull();
   expect(submittedPayload.url).toBe(testUrl);
   expect(submittedPayload.quality).toBe('LOSSLESS');

--- a/website/tests/status.spec.js
+++ b/website/tests/status.spec.js
@@ -79,4 +79,40 @@ test.describe("Connection Status Indicator", () => {
     await expect(statusContainer).toHaveClass(/status-offline/);
     await expect(statusContainer.locator(".status-text")).toHaveText("Offline");
   });
+  test("shows offline status when health endpoint times out", async ({ page }) => {
+    // We expect the frontend to time out after 5 seconds, so we need a slightly longer timeout for the test to wait for the UI update.
+    test.setTimeout(15000);
+    await page.route("**/api/health", () => {
+      // Do not fulfill, simulate a hang
+    });
+
+    await page.route("**/api/jobs", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+    await page.route("**/api/system/storage", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total: 100, used: 10, free: 90 }),
+      });
+    });
+    await page.route("**/api/stats", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 }),
+      });
+    });
+
+    await page.goto("/");
+
+    const statusContainer = page.locator("#connection-status");
+    await expect(statusContainer).toBeVisible();
+    await expect(statusContainer).toHaveClass(/status-offline/, { timeout: 10000 });
+    await expect(statusContainer.locator(".status-text")).toHaveText("Offline", { timeout: 10000 });
+  });
 });


### PR DESCRIPTION
The UI currently polls `/api/health` to determine connection status. However, if the backend hangs indefinitely, the UI fetch request will wait for the browser's default timeout, causing the UI to falsely appear online.

This patch implements an `AbortController` and `setTimeout` (5 seconds) for the `/api/health` fetch request in the frontend. It successfully aborts the request, causing the status indicator to fall into the catch block and display "Offline". A test simulating a hanging backend was added to verify the functionality.

---
*PR created automatically by Jules for task [13442170059892039638](https://jules.google.com/task/13442170059892039638) started by @jjgroenendijk*