### PR TITLE
feat: Add global Cmd/Ctrl+K keyboard shortcut for job search

### DIFF
--- a/docs/backlog/done/046_cmd_k_shortcut.md
+++ b/docs/backlog/done/046_cmd_k_shortcut.md
@@ -1,0 +1,10 @@
+# Cmd+K / Ctrl+K Global Shortcut
+
+Implement a global keyboard shortcut (Cmd+K on Mac, Ctrl+K on Windows/Linux) to focus the job search input field.
+This is a common convention in modern web applications that improves keyboard navigation and usability.
+
+When the user presses the shortcut:
+1. The default browser behavior (if any) should be prevented
+2. The search input (`#job-search-input`) should be focused
+
+We should also add a visual indicator (like a small badge saying `Cmd K` or `Ctrl K`) inside or next to the search bar so users know the shortcut exists.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -248,8 +248,11 @@ export function renderApp(root) {
         <div class="section-heading section-heading-with-action">
           <h2>Recent jobs</h2>
           <div class="job-controls-row">
-            <input type="text" id="job-search-input" placeholder="Search URL or ID..." class="job-search-input" aria-label="Search jobs" />
-            <button type="button" id="clear-search-btn" class="clear-search-btn hidden-btn" aria-label="Clear search">X</button>
+            <div class="search-input-container">
+              <input type="text" id="job-search-input" placeholder="Search URL or ID..." class="job-search-input" aria-label="Search jobs" />
+              <kbd class="search-shortcut-badge" id="search-shortcut-badge"></kbd>
+              <button type="button" id="clear-search-btn" class="clear-search-btn hidden-btn" aria-label="Clear search">X</button>
+            </div>
             <select id="job-sort-select" class="job-status-filter clear-history-btn" aria-label="Sort jobs">
               <option value="newest">Newest First</option>
               <option value="oldest">Oldest First</option>
@@ -727,6 +730,23 @@ export function renderApp(root) {
       applyCompactViewState();
     });
   }
+
+  const searchShortcutBadge = root.querySelector("#search-shortcut-badge");
+  if (searchShortcutBadge) {
+    const isMac = navigator.userAgent.toLowerCase().includes('mac');
+    searchShortcutBadge.textContent = isMac ? '⌘K' : 'Ctrl K';
+  }
+
+  // Global Keyboard Shortcut for Search (Cmd/Ctrl + K)
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      const searchInput = root.querySelector("#job-search-input");
+      if (searchInput) {
+        searchInput.focus();
+      }
+    }
+  });
 
   // Initial load
   fetchJobs();

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -358,12 +358,14 @@ export function renderApp(root) {
       }
     });
 
-  input.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
-      event.preventDefault();
-      form.requestSubmit();
-    }
-  });
+  if (input) {
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        form.requestSubmit();
+      }
+    });
+  }
   }
 
   if (clearInputBtn) {

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -640,9 +640,38 @@ button:active {
   color: var(--text-primary);
 }
 
+.search-input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 250px;
+}
+
+.job-search-input {
+  width: 100%;
+}
+
+.search-shortcut-badge {
+  position: absolute;
+  right: 12px;
+  padding: 2px 6px;
+  background-color: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 4px;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  pointer-events: none;
+  font-family: inherit;
+}
+
+.job-search-input:focus + .search-shortcut-badge,
+.job-search-input:not(:placeholder-shown) + .search-shortcut-badge {
+  display: none;
+}
+
 .job-search-input {
   min-height: auto;
-  padding: 6px 12px;
+  padding: 6px 60px 6px 12px;
   border-radius: 8px;
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
@@ -661,6 +690,8 @@ button:active {
 }
 
 .clear-search-btn {
+  position: absolute;
+  right: 12px;
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
   padding: 6px 12px;

--- a/website/tests/search-shortcut.spec.js
+++ b/website/tests/search-shortcut.spec.js
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Search Shortcut Cmd+K / Ctrl+K', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept backend requests
+    await page.route('**/api/jobs', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    }));
+    await page.route('**/api/system/storage', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total: 1000, used: 500, free: 500 })
+    }));
+    await page.route('**/api/system/info', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ version: '1.0', platform: 'test' })
+    }));
+    await page.route('**/api/stats', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total_jobs: 0, total_files: 0, success_rate: 0 })
+    }));
+    await page.route('**/api/health', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'ok' })
+    }));
+
+    await page.goto('http://127.0.0.1:3000');
+  });
+
+  test('Focuses search input when Control+K is pressed', async ({ page }) => {
+    // Make sure the input is not initially focused
+    await expect(page.locator('#job-search-input')).not.toBeFocused();
+
+    // Press Ctrl+K
+    await page.keyboard.press('Control+k');
+
+    // The input should now be focused
+    await expect(page.locator('#job-search-input')).toBeFocused();
+  });
+
+  test('Focuses search input when Meta+K is pressed', async ({ page }) => {
+    // Make sure the input is not initially focused
+    await expect(page.locator('#job-search-input')).not.toBeFocused();
+
+    // Press Meta+K (Cmd+K)
+    await page.keyboard.press('Meta+k');
+
+    // The input should now be focused
+    await expect(page.locator('#job-search-input')).toBeFocused();
+  });
+});


### PR DESCRIPTION
Added a global keyboard shortcut (Cmd/Ctrl+K) to focus the search input field. Also added a visual keyboard badge to indicate the shortcut, which dynamically adapts to the user's platform (Mac vs. Windows/Linux) and hides gracefully when the input is focused or contains text. Includes E2E tests for verification.

---
*PR created automatically by Jules for task [17230376504323154923](https://jules.google.com/task/17230376504323154923) started by @jjgroenendijk*