### PR TITLE
feat(web): persist job status filter and add download loading state

### DIFF
--- a/docs/backlog/closed/045_download_button_loading_state.md
+++ b/docs/backlog/closed/045_download_button_loading_state.md
@@ -1,0 +1,3 @@
+# Download Button Loading State
+
+The download buttons (e.g. download all) should show a loading indicator or disable state while the download zip is being generated, since it can take a long time and the UI currently has no indication of progress.

--- a/docs/backlog/closed/046_job_status_filter_local_storage.md
+++ b/docs/backlog/closed/046_job_status_filter_local_storage.md
@@ -1,0 +1,3 @@
+# Persist Job Status Filter in Local Storage
+
+The job status filter (All, Queued, Completed, Failed) should be persisted to Local Storage so that when the user refreshes the page or comes back later, their preferred filter is still applied.

--- a/website/src/app.js
+++ b/website/src/app.js
@@ -319,6 +319,32 @@ export function renderApp(root) {
   const searchInput = root.querySelector("#job-search-input");
   const clearSearchBtn = root.querySelector("#clear-search-btn");
   const sortSelect = root.querySelector("#job-sort-select");
+
+  // Load persisted status filter if any
+  const savedStatusFilter = localStorage.getItem("jobStatusFilter");
+  if (savedStatusFilter && statusFilter) {
+    statusFilter.value = savedStatusFilter;
+  }
+
+  const downloadAllBtn = root.querySelector("#download-all-btn");
+  if (downloadAllBtn) {
+    downloadAllBtn.addEventListener("click", () => {
+      if (downloadAllBtn.classList.contains("loading")) return;
+
+      const originalText = downloadAllBtn.textContent;
+      downloadAllBtn.textContent = "Preparing Download...";
+      downloadAllBtn.classList.add("loading");
+      downloadAllBtn.style.pointerEvents = "none";
+      downloadAllBtn.style.opacity = "0.7";
+
+      setTimeout(() => {
+        downloadAllBtn.textContent = originalText;
+        downloadAllBtn.classList.remove("loading");
+        downloadAllBtn.style.pointerEvents = "auto";
+        downloadAllBtn.style.opacity = "1";
+      }, 5000);
+    });
+  }
   const clearInputBtn = root.querySelector("#clear-input-btn");
   const loadFileBtn = root.querySelector("#load-file-btn");
   const bulkUrlFileInput = root.querySelector("#bulk-url-file-input");
@@ -643,7 +669,10 @@ export function renderApp(root) {
   }
 
   if (statusFilter) {
-    statusFilter.addEventListener("change", fetchJobs);
+    statusFilter.addEventListener("change", () => {
+      localStorage.setItem("jobStatusFilter", statusFilter.value);
+      fetchJobs();
+    });
   }
 
   if (sortSelect) {


### PR DESCRIPTION
- Updated `website/src/app.js` to persist the job status filter to `localStorage` and restore it on init.
- Added an event listener to `#download-all-btn` that sets a visual "Preparing Download..." state for 5 seconds when clicked.
- Moved backlog items 045 and 046 to closed.

---
*PR created automatically by Jules for task [11775895888834196566](https://jules.google.com/task/11775895888834196566) started by @jjgroenendijk*